### PR TITLE
Bidirection parameters rb extension sdk9

### DIFF
--- a/conformance_tests/test_tiovx/test_bidir_ext_framework.c
+++ b/conformance_tests/test_tiovx/test_bidir_ext_framework.c
@@ -1,0 +1,963 @@
+/*
+ * Copyright (c) 2013-2023 The Khronos Group Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "test_engine/test.h"
+#include "test_tiovx/test_tiovx.h"
+
+#include <VX/vx.h>
+#include <TI/tivx.h>
+#include <TI/tivx_task.h>
+#include <VX/vx_khr_pipelining.h>
+
+enum user_library_e
+{
+    USER_LIBRARY_EXAMPLE = 1
+};
+
+enum user_kernel_e
+{
+  MY_USER_KERNEL = VX_KERNEL_BASE( VX_ID_USER, USER_LIBRARY_EXAMPLE ) + 0x001
+};
+
+TESTCASE(bpExtFramework, CT_VXContext, ct_setup_vx_context, 0)
+
+/* Write some data on an image */
+void writeImage(vx_image image)
+{
+    vx_map_id id;
+    vx_rectangle_t rect = {.start_x = 0, .end_x = 1, .start_y = 0, .end_y = 2};
+    vx_imagepatch_addressing_t ipa;
+    void *ptr;
+    VX_CALL(vxMapImagePatch(image, &rect, 0, &id, &ipa, &ptr, VX_READ_AND_WRITE, VX_MEMORY_TYPE_HOST, 0));
+    *(vx_uint8 *)vxFormatImagePatchAddress2d(ptr, 0, 0, &ipa) = 1;
+    *(vx_uint8 *)vxFormatImagePatchAddress2d(ptr, 0, 1, &ipa) = 2;
+    VX_CALL(vxUnmapImagePatch(image, id));
+}
+
+/* Check data in an image */
+vx_status checkImage(vx_image image, vx_uint8 a, vx_uint8 b)
+{
+    vx_status status = (vx_status)VX_SUCCESS;
+    vx_map_id id;
+    vx_rectangle_t rect = {.start_x = 0, .end_x = 1, .start_y = 0, .end_y = 2};
+    vx_imagepatch_addressing_t ipa;
+    void *ptr;
+    status = vxMapImagePatch(image, &rect, 0, &id, &ipa, &ptr, VX_READ_AND_WRITE, VX_MEMORY_TYPE_HOST, 0);
+    if (status != (vx_status)VX_SUCCESS)
+    {
+        return status;
+    }
+    vx_uint8 aa = *(vx_uint8 *)vxFormatImagePatchAddress2d(ptr, 0, 0, &ipa);
+    vx_uint8 bb = *(vx_uint8 *)vxFormatImagePatchAddress2d(ptr, 0, 1, &ipa);
+    status = vxUnmapImagePatch(image, id);
+    if (status != (vx_status)VX_SUCCESS)
+    {
+        return status;
+    }
+    if (aa == a && bb == b)
+    {
+        status = (vx_status)VX_SUCCESS;
+    }
+    else
+    {
+        status = (vx_status)VX_FAILURE;
+    }
+    return status;
+}
+
+vx_status myKernelFunction(vx_node node, const vx_reference parameters[], vx_uint32 nparams)
+{
+    /* Implement a very simple operation on two of the pixels so that we can verify
+    that things have happened as they should, in the order they should. We will perform
+    these operations:
+    bidir(0,0) = bidir(0, 0) + input(0,0) + 1
+    bidir(0,1) = bidir(0, 1) + input(0,1) + 2
+    */
+    vx_status status = (vx_status)VX_SUCCESS;
+    vx_image input = (vx_image)parameters[0];
+    vx_image bidir = (vx_image)parameters[1];
+    vx_map_id id_in, id_bid;
+    vx_rectangle_t rect = {.start_x = 0, .end_x = 1, .start_y = 0, .end_y = 2};
+    vx_imagepatch_addressing_t ipa_in, ipa_bid;
+    void *ptr_in, *ptr_bid;
+    tivxTaskWaitMsecs(100); /* Slow this kernel down so anything executing in parallel may complete */
+    status = vxMapImagePatch(input, &rect, 0, &id_in, &ipa_in, &ptr_in, VX_READ_ONLY, VX_MEMORY_TYPE_HOST, 0);
+    if (status != (vx_status)VX_SUCCESS)
+    {
+        return status;
+    }
+    status = vxMapImagePatch(bidir, &rect, 0, &id_bid, &ipa_bid, &ptr_bid, VX_READ_AND_WRITE, VX_MEMORY_TYPE_HOST, 0);
+    if (status != (vx_status)VX_SUCCESS)
+    {
+        return status;
+    }
+    vx_uint8 inpix1 = *(vx_uint8 *)vxFormatImagePatchAddress2d(ptr_in, 0, 0, &ipa_in);
+    vx_uint8 inpix2 = *(vx_uint8 *)vxFormatImagePatchAddress2d(ptr_in, 0, 1, &ipa_in);
+    vx_uint8 bidpix1 = *(vx_uint8 *)vxFormatImagePatchAddress2d(ptr_bid, 0, 0, &ipa_bid);
+    vx_uint8 bidpix2 = *(vx_uint8 *)vxFormatImagePatchAddress2d(ptr_bid, 0, 1, &ipa_bid);
+    vx_uint8 respix1 = inpix1 + bidpix1 + 1;
+    vx_uint8 respix2 = inpix2 + bidpix2 + 2;
+
+    *(vx_uint8 *)vxFormatImagePatchAddress2d(ptr_bid, 0, 0, &ipa_bid) = respix1;
+    *(vx_uint8 *)vxFormatImagePatchAddress2d(ptr_bid, 0, 1, &ipa_bid) = respix2;
+
+    status = vxUnmapImagePatch(input, id_in);
+    if (status != (vx_status)VX_SUCCESS)
+    {
+        return status;
+    }
+    status = vxUnmapImagePatch(bidir, id_bid);
+    return status;
+}
+
+vx_status myKernelValidator(vx_node node, const vx_reference * parameters, vx_uint32 num, vx_meta_format * metas)
+{
+    return VX_SUCCESS;
+}
+
+/* Create a user kernel */
+vx_status registerUserKernel(vx_context context)
+{
+    vx_status status = (vx_status)VX_SUCCESS;
+    vx_kernel kernel = vxAddUserKernel(context, "myUserKernel", MY_USER_KERNEL, myKernelFunction, 2, myKernelValidator, NULL, NULL);
+    EXPECT_VX_REFERENCE(kernel);
+    status = vxAddParameterToKernel(kernel, 0, VX_INPUT, VX_TYPE_IMAGE, VX_PARAMETER_STATE_REQUIRED);
+    if (status != (vx_status)VX_SUCCESS)
+    {
+        return status;
+    }
+    /* Check [REQ-BP01] at compile time */
+    (void)VX_BIDIRECTIONAL;
+    //PASS("BP01");
+    /* Check [REQ-BP02] */
+    status = vxAddParameterToKernel(kernel, 1, VX_BIDIRECTIONAL, VX_TYPE_IMAGE, VX_PARAMETER_STATE_REQUIRED);
+    if (status != (vx_status)VX_SUCCESS)
+    {
+        return status;
+    }
+    status = vxFinalizeKernel(kernel);
+    if (status != (vx_status)VX_SUCCESS)
+    {
+        return status;
+    }
+    status = vxReleaseKernel(&kernel);
+    return status;
+}
+
+vx_status unRegisterUserKernel(vx_context context)
+{
+    return (vxRemoveKernel(vxGetKernelByEnum(context, MY_USER_KERNEL)));
+}
+
+/* Create a simple node with a bidirectional parameter */
+vx_node createUserNode(vx_graph graph, vx_image input, vx_image bidir)
+{
+    vx_context context = vxGetContext((vx_reference)graph);
+    vx_kernel kernel = vxGetKernelByEnum(context, MY_USER_KERNEL);
+    EXPECT_VX_REFERENCE(kernel);
+    vx_node node = vxCreateGenericNode(graph, kernel);
+    EXPECT_VX_REFERENCE(node);
+    vxSetParameterByIndex(node, 0, (vx_reference)input);
+    vxSetParameterByIndex(node, 1, (vx_reference)bidir);
+    vxReleaseKernel(&kernel);
+    return node;
+}
+
+/* Function to get a parameter, add it to a graph and then release it */
+vx_status addParameterToGraph(vx_graph graph, vx_node node, vx_uint32 num)
+{
+    vx_status status = (vx_status)VX_SUCCESS;
+    vx_parameter p = vxGetParameterByIndex(node, num);
+    status = vxAddParameterToGraph(graph, p);
+    if (status != (vx_status)VX_SUCCESS)
+    {
+        return status;
+    }
+    status = vxReleaseParameter(&p);
+    return status;
+}
+
+/* Graphs that should fail verification */
+/* Create a graph with a non-virtual attached to one output, two bidirectional and two inputs */
+void makeGraph1O2B2I(vx_context context)
+{
+    vx_graph graph;
+    vx_image image1, image2, image3;
+
+    ASSERT_VX_OBJECT(graph = vxCreateGraph(context), VX_TYPE_GRAPH);
+    ASSERT_VX_OBJECT(image1 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    ASSERT_VX_OBJECT(image2 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    ASSERT_VX_OBJECT(image3 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    writeImage(image1);
+    vx_node nodea = createUserNode(graph, image1, image2);
+    EXPECT_VX_REFERENCE(nodea);
+    vx_node nodeb = createUserNode(graph, image1, image2);
+    EXPECT_VX_REFERENCE(nodeb);
+    vx_node nodec = vxNotNode(graph, image1, image2);
+    EXPECT_VX_REFERENCE(nodec);
+    vx_node noded = vxAndNode(graph, image2, image2, image3);
+    EXPECT_VX_REFERENCE(noded);
+    EXPECT_NE_VX_STATUS(VX_SUCCESS, vxVerifyGraph(graph));
+    VX_CALL(vxReleaseNode(&nodea));
+    VX_CALL(vxReleaseNode(&nodeb));
+    VX_CALL(vxReleaseNode(&nodec));
+    VX_CALL(vxReleaseNode(&noded));
+    VX_CALL(vxReleaseImage(&image1));
+    VX_CALL(vxReleaseImage(&image2));
+    VX_CALL(vxReleaseImage(&image3));
+    VX_CALL(vxReleaseGraph(&graph));
+}
+
+/* Create a graph with a non-virtual attached to two bidirectional and two inputs */
+void makeGraph2B2I(vx_context context)
+{
+    vx_graph graph;
+    vx_image image1, image2, image3;
+
+    ASSERT_VX_OBJECT(graph = vxCreateGraph(context), VX_TYPE_GRAPH);
+    ASSERT_VX_OBJECT(image1 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    ASSERT_VX_OBJECT(image2 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    ASSERT_VX_OBJECT(image3 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    vx_node nodea = createUserNode(graph, image1, image2);
+    EXPECT_VX_REFERENCE(nodea);
+    vx_node nodeb = createUserNode(graph, image1, image2);
+    EXPECT_VX_REFERENCE(nodeb);
+    vx_node noded = vxAndNode(graph, image2, image2, image3);
+    EXPECT_VX_REFERENCE(noded);
+    writeImage(image1);
+    EXPECT_NE_VX_STATUS(VX_SUCCESS, vxVerifyGraph(graph));
+    VX_CALL(vxReleaseNode(&nodea));
+    VX_CALL(vxReleaseNode(&nodeb));
+    VX_CALL(vxReleaseNode(&noded));
+    VX_CALL(vxReleaseImage(&image1));
+    VX_CALL(vxReleaseImage(&image2));
+    VX_CALL(vxReleaseImage(&image3));
+    VX_CALL(vxReleaseGraph(&graph));
+}
+
+/* Create a graph with a non-virtual attached to one output, two bidirectional */
+void makeGraph1O2B(vx_context context)
+{
+    vx_graph graph;
+    vx_image image1, image2;
+
+    ASSERT_VX_OBJECT(graph = vxCreateGraph(context), VX_TYPE_GRAPH);
+    ASSERT_VX_OBJECT(image1 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    ASSERT_VX_OBJECT(image2 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    vx_node nodea = createUserNode(graph, image1, image2);
+    EXPECT_VX_REFERENCE(nodea);
+    vx_node nodeb = createUserNode(graph, image1, image2);
+    EXPECT_VX_REFERENCE(nodeb);
+    vx_node nodec = vxNotNode(graph, image1, image2);
+    EXPECT_VX_REFERENCE(nodec);
+    writeImage(image1);
+    EXPECT_NE_VX_STATUS(VX_SUCCESS, vxVerifyGraph(graph));
+    VX_CALL(vxReleaseNode(&nodea));
+    VX_CALL(vxReleaseNode(&nodeb));
+    VX_CALL(vxReleaseNode(&nodec));
+    VX_CALL(vxReleaseImage(&image1));
+    VX_CALL(vxReleaseImage(&image2));
+    VX_CALL(vxReleaseGraph(&graph));
+}
+
+/* Create a graph with a non-virtual attached to two bidirectional */
+void makeGraph2B(vx_context context)
+{
+    vx_graph graph;
+    vx_image image1, image2;
+
+    ASSERT_VX_OBJECT(graph = vxCreateGraph(context), VX_TYPE_GRAPH);
+    ASSERT_VX_OBJECT(image1 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    ASSERT_VX_OBJECT(image2 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    vx_node nodea = createUserNode(graph, image1, image2);
+    EXPECT_VX_REFERENCE(nodea);
+    vx_node nodeb = createUserNode(graph, image1, image2);
+    EXPECT_VX_REFERENCE(nodeb);
+    writeImage(image1);
+    EXPECT_NE_VX_STATUS(VX_SUCCESS, vxVerifyGraph(graph));
+    VX_CALL(vxReleaseNode(&nodea));
+    VX_CALL(vxReleaseNode(&nodeb));
+    VX_CALL(vxReleaseImage(&image1));
+    VX_CALL(vxReleaseImage(&image2));
+    VX_CALL(vxReleaseGraph(&graph));
+}
+
+/* Create a graph with a virtual attached to one output, two bidirectional and one input */
+void makeGraphV1O2B1I(vx_context context)
+{
+    vx_graph graph;
+    vx_image image1, image2, image3;
+
+    ASSERT_VX_OBJECT(graph = vxCreateGraph(context), VX_TYPE_GRAPH);
+    ASSERT_VX_OBJECT(image1 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    ASSERT_VX_OBJECT(image2 = vxCreateVirtualImage(graph, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    ASSERT_VX_OBJECT(image3 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    vx_node nodea = createUserNode(graph, image1, image2);
+    EXPECT_VX_REFERENCE(nodea);
+    vx_node nodeb = createUserNode(graph, image1, image2);
+    EXPECT_VX_REFERENCE(nodeb);
+    vx_node nodec = vxNotNode(graph, image1, image2);
+    EXPECT_VX_REFERENCE(nodec);
+    vx_node noded = vxNotNode(graph, image2, image3);
+    EXPECT_VX_REFERENCE(noded);
+    writeImage(image1);
+    EXPECT_NE_VX_STATUS(VX_SUCCESS, vxVerifyGraph(graph));
+    VX_CALL(vxReleaseNode(&nodea));
+    VX_CALL(vxReleaseNode(&nodeb));
+    VX_CALL(vxReleaseNode(&nodec));
+    VX_CALL(vxReleaseNode(&noded));
+    VX_CALL(vxReleaseImage(&image1));
+    VX_CALL(vxReleaseImage(&image2));
+    VX_CALL(vxReleaseImage(&image3));
+    VX_CALL(vxReleaseGraph(&graph));
+}
+
+/* Create a graph with a virtual attached to one bidirectional and one input */
+void makeGraphV1B1I(vx_context context)
+{
+    vx_graph graph;
+    vx_image image1, image2, image3;
+
+    ASSERT_VX_OBJECT(graph = vxCreateGraph(context), VX_TYPE_GRAPH);
+    ASSERT_VX_OBJECT(image1 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    ASSERT_VX_OBJECT(image2 = vxCreateVirtualImage(graph, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    ASSERT_VX_OBJECT(image3 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    vx_node nodea = createUserNode(graph, image1, image2);
+    EXPECT_VX_REFERENCE(nodea);
+    vx_node noded = vxNotNode(graph, image2, image3);
+    EXPECT_VX_REFERENCE(noded);
+    writeImage(image1);
+    EXPECT_NE_VX_STATUS(VX_SUCCESS, vxVerifyGraph(graph));
+    VX_CALL(vxReleaseNode(&nodea));
+    VX_CALL(vxReleaseNode(&noded));
+    VX_CALL(vxReleaseImage(&image1));
+    VX_CALL(vxReleaseImage(&image2));
+    VX_CALL(vxReleaseImage(&image3));
+    VX_CALL(vxReleaseGraph(&graph));
+}
+
+/* Create a graph with a virtual attached to one output, one bidirectional */
+void makeGraphV1O1B(vx_context context)
+{
+    vx_graph graph;
+    vx_image image1, image2;
+
+    ASSERT_VX_OBJECT(graph = vxCreateGraph(context),  VX_TYPE_GRAPH);
+    ASSERT_VX_OBJECT(image1 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    ASSERT_VX_OBJECT(image2 = vxCreateVirtualImage(graph, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    vx_node nodea = createUserNode(graph, image1, image2);
+    EXPECT_VX_REFERENCE(nodea);
+    vx_node nodec = vxNotNode(graph, image1, image2);
+    EXPECT_VX_REFERENCE(nodec);
+    writeImage(image1);
+    EXPECT_NE_VX_STATUS(VX_SUCCESS, vxVerifyGraph(graph));
+    VX_CALL(vxReleaseNode(&nodea));
+    VX_CALL(vxReleaseNode(&nodec));
+    VX_CALL(vxReleaseImage(&image1));
+    VX_CALL(vxReleaseImage(&image2));
+    VX_CALL(vxReleaseGraph(&graph));
+}
+
+/* Create a graph with a virtual attached to one bidirectional */
+void makeGraphV1B(vx_context context)
+{
+    vx_graph graph;
+    vx_image image1, image2;
+
+    ASSERT_VX_OBJECT(graph = vxCreateGraph(context), VX_TYPE_GRAPH);
+    ASSERT_VX_OBJECT(image1 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    ASSERT_VX_OBJECT(image2 = vxCreateVirtualImage(graph, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    vx_node nodea = createUserNode(graph, image1, image2);
+    EXPECT_VX_REFERENCE(nodea);
+    writeImage(image1);
+    EXPECT_NE_VX_STATUS(VX_SUCCESS, vxVerifyGraph(graph));
+    VX_CALL(vxReleaseNode(&nodea));
+    VX_CALL(vxReleaseImage(&image1));
+    VX_CALL(vxReleaseImage(&image2));
+    VX_CALL(vxReleaseGraph(&graph));
+}
+
+/* Create a graph with a non-virtual attached to a bidirectional and an input of the same node */
+void makeGraphCycle0(vx_context context)
+{
+    vx_graph graph;
+    vx_image image1;
+
+    ASSERT_VX_OBJECT(graph = vxCreateGraph(context), VX_TYPE_GRAPH);
+    ASSERT_VX_OBJECT(image1 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    vx_node nodea = createUserNode(graph, image1, image1);
+    EXPECT_VX_REFERENCE(nodea);
+    writeImage(image1);
+    EXPECT_NE_VX_STATUS(VX_SUCCESS, vxVerifyGraph(graph));
+    VX_CALL(vxReleaseNode(&nodea));
+    VX_CALL(vxReleaseImage(&image1));
+    VX_CALL(vxReleaseGraph(&graph));
+}
+
+/* Create a graph with a cycle:
+      object 1 is connected as bidirectional to node A and input to node B,
+      object 2 is connected as bidirectional to node B and input to node A */
+void makeGraphCycle1(vx_context context)
+{
+    vx_graph graph;
+    vx_image image1, image2;
+
+    ASSERT_VX_OBJECT(graph = vxCreateGraph(context), VX_TYPE_GRAPH);
+    ASSERT_VX_OBJECT(image1 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    ASSERT_VX_OBJECT(image2 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    vx_node nodea = createUserNode(graph, image2, image1);
+    EXPECT_VX_REFERENCE(nodea);
+    vx_node nodeb = createUserNode(graph, image1, image2);
+    EXPECT_VX_REFERENCE(nodeb);
+    writeImage(image1);
+    writeImage(image2);
+    EXPECT_NE_VX_STATUS(VX_SUCCESS, vxVerifyGraph(graph));
+    VX_CALL(vxReleaseNode(&nodea));
+    VX_CALL(vxReleaseNode(&nodeb));
+    VX_CALL(vxReleaseImage(&image2));
+    VX_CALL(vxReleaseImage(&image1));
+    VX_CALL(vxReleaseGraph(&graph));
+}
+
+/* Create a graph with a cycle:
+       object 1 is connected as an input to node A, as bidirectional to node B
+       and the output of node A is connected as another input to node B */
+void makeGraphCycle2(vx_context context)
+{
+    vx_graph graph;
+    vx_image image1, image2;
+
+    ASSERT_VX_OBJECT(graph = vxCreateGraph(context), VX_TYPE_GRAPH);
+    ASSERT_VX_OBJECT(image1 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    ASSERT_VX_OBJECT(image2 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    vx_node nodea = vxNotNode(graph, image1, image2);
+    EXPECT_VX_REFERENCE(nodea);
+    vx_node nodeb = createUserNode(graph, image2, image1);
+    EXPECT_VX_REFERENCE(nodeb);
+    writeImage(image2);
+    writeImage(image1);
+    EXPECT_NE_VX_STATUS(VX_SUCCESS, vxVerifyGraph(graph));
+    VX_CALL(vxReleaseNode(&nodea));
+    VX_CALL(vxReleaseNode(&nodeb));
+    VX_CALL(vxReleaseImage(&image2));
+    VX_CALL(vxReleaseImage(&image1));
+    VX_CALL(vxReleaseGraph(&graph));
+}
+
+/* Create a graph with a uniform image attached as a bidirectional */
+void makeGraphUniform(vx_context context)
+{
+    vx_graph graph;
+    vx_image image1, image2;
+
+    ASSERT_VX_OBJECT(graph = vxCreateGraph(context), VX_TYPE_GRAPH);
+    ASSERT_VX_OBJECT(image1 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    vx_pixel_value_t pixel = {.U32 = 0};
+    ASSERT_VX_OBJECT(image2 = vxCreateUniformImage(context, 100, 100, VX_DF_IMAGE_U8, &pixel), VX_TYPE_IMAGE);
+    vx_node nodea = createUserNode(graph, image1, image2);
+    EXPECT_VX_REFERENCE(nodea);
+    writeImage(image1);
+    EXPECT_NE_VX_STATUS(VX_SUCCESS, vxVerifyGraph(graph));
+    VX_CALL(vxReleaseNode(&nodea));
+    VX_CALL(vxReleaseImage(&image1));
+    VX_CALL(vxReleaseImage(&image2));
+    VX_CALL(vxReleaseGraph(&graph));
+}
+
+/* Graphs that should pass verification */
+/* Create a graph with a non-virtual attached to one output, one bidirectional and two inputs */
+void makeGraph1O1B2I(vx_context context)
+{
+    vx_graph graph;
+    vx_image image1, image2, image3;
+
+    ASSERT_VX_OBJECT(graph = vxCreateGraph(context), VX_TYPE_GRAPH);
+    ASSERT_VX_OBJECT(image1 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    ASSERT_VX_OBJECT(image2 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    ASSERT_VX_OBJECT(image3 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    vx_node nodeb = createUserNode(graph, image1, image2);
+    EXPECT_VX_REFERENCE(nodeb);
+    vx_node nodec = vxNotNode(graph, image1, image2);
+    EXPECT_VX_REFERENCE(nodec);
+    vx_node noded = vxAndNode(graph, image2, image2, image3);
+    EXPECT_VX_REFERENCE(noded);
+    writeImage(image1);
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, vxProcessGraph(graph));
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, checkImage(image3, 0, 1));
+    VX_CALL(vxReleaseNode(&nodeb));
+    VX_CALL(vxReleaseNode(&nodec));
+    VX_CALL(vxReleaseNode(&noded));
+    VX_CALL(vxReleaseImage(&image1));
+    VX_CALL(vxReleaseImage(&image2));
+    VX_CALL(vxReleaseImage(&image3));
+    VX_CALL(vxReleaseGraph(&graph));
+}
+
+/* Create a graph with a non-virtual attached to one bidirectional and two inputs */
+void makeGraph1B2I(vx_context context)
+{
+    vx_graph graph;
+    vx_image image1, image2, image3;
+
+    ASSERT_VX_OBJECT(graph = vxCreateGraph(context), VX_TYPE_GRAPH);
+    ASSERT_VX_OBJECT(image1 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    ASSERT_VX_OBJECT(image2 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    ASSERT_VX_OBJECT(image3 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    vx_node nodeb = createUserNode(graph, image1, image2);
+    EXPECT_VX_REFERENCE(nodeb);
+    vx_node noded = vxAndNode(graph, image2, image2, image3);
+    EXPECT_VX_REFERENCE(noded);
+    writeImage(image1);
+    writeImage(image2);
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, vxProcessGraph(graph));
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, checkImage(image3, 3, 6));
+    VX_CALL(vxReleaseNode(&nodeb));
+    VX_CALL(vxReleaseNode(&noded));
+    VX_CALL(vxReleaseImage(&image1));
+    VX_CALL(vxReleaseImage(&image2));
+    VX_CALL(vxReleaseImage(&image3));
+    VX_CALL(vxReleaseGraph(&graph));
+}
+
+/* Create a graph with a non-virtual attached to one output, one bidirectional */
+void makeGraph1O1B(vx_context context)
+{
+    vx_graph graph;
+    vx_image image1, image2;
+
+    ASSERT_VX_OBJECT(graph = vxCreateGraph(context), VX_TYPE_GRAPH);
+    ASSERT_VX_OBJECT(image1 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    ASSERT_VX_OBJECT(image2 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    vx_node nodeb = createUserNode(graph, image1, image2);
+    EXPECT_VX_REFERENCE(nodeb);
+    vx_node nodec = vxNotNode(graph, image1, image2);
+    EXPECT_VX_REFERENCE(nodec);
+    writeImage(image1);
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, vxProcessGraph(graph));
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, checkImage(image2, 0, 1));
+    VX_CALL(vxReleaseNode(&nodeb));
+    VX_CALL(vxReleaseNode(&nodec));
+    VX_CALL(vxReleaseImage(&image1));
+    VX_CALL(vxReleaseImage(&image2));
+    VX_CALL(vxReleaseGraph(&graph));
+}
+
+/* Create a graph with a non-virtual attached to one bidirectional */
+void makeGraph1B(vx_context context)
+{
+    vx_graph graph;
+    vx_image image1, image2;
+
+    ASSERT_VX_OBJECT(graph = vxCreateGraph(context), VX_TYPE_GRAPH);
+    ASSERT_VX_OBJECT(image1 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    ASSERT_VX_OBJECT(image2 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    vx_node nodea = createUserNode(graph, image1, image2);
+    EXPECT_VX_REFERENCE(nodea);
+    writeImage(image1);
+    writeImage(image2);
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, vxProcessGraph(graph));
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, checkImage(image2, 3, 6));
+    VX_CALL(vxReleaseNode(&nodea));
+    VX_CALL(vxReleaseImage(&image1));
+    VX_CALL(vxReleaseImage(&image2));
+    VX_CALL(vxReleaseGraph(&graph));
+}
+
+/* Create a graph with a virtual attached to one output, one bidirectional and one input */
+void makeGraphV1O1B1I(vx_context context)
+{
+    vx_graph graph;
+    vx_image image1, image2, image3;
+
+    ASSERT_VX_OBJECT(graph = vxCreateGraph(context), VX_TYPE_GRAPH);
+    ASSERT_VX_OBJECT(image1 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    ASSERT_VX_OBJECT(image2 = vxCreateVirtualImage(graph, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    ASSERT_VX_OBJECT(image3 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    vx_node nodeb = createUserNode(graph, image1, image2);
+    EXPECT_VX_REFERENCE(nodeb);
+    vx_node nodec = vxNotNode(graph, image1, image2);
+    EXPECT_VX_REFERENCE(nodec);
+    vx_node noded = vxNotNode(graph, image2, image3);
+    EXPECT_VX_REFERENCE(noded);
+    writeImage(image1);
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, vxProcessGraph(graph));
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, checkImage(image3, 255, 254));
+    VX_CALL(vxReleaseNode(&nodeb));
+    VX_CALL(vxReleaseNode(&nodec));
+    VX_CALL(vxReleaseNode(&noded));
+    VX_CALL(vxReleaseImage(&image1));
+    VX_CALL(vxReleaseImage(&image2));
+    VX_CALL(vxReleaseImage(&image3));
+    VX_CALL(vxReleaseGraph(&graph));
+}
+
+/* Create a graph with a virtual attached to one output, one bidirectional and three inputs */
+void makeGraphV1O1B3I(vx_context context)
+{
+    vx_graph graph;
+    vx_image image1, image2, image3, image4;
+
+    ASSERT_VX_OBJECT(graph = vxCreateGraph(context), VX_TYPE_GRAPH);
+    ASSERT_VX_OBJECT(image1 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    ASSERT_VX_OBJECT(image2 = vxCreateVirtualImage(graph, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    ASSERT_VX_OBJECT(image3 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    ASSERT_VX_OBJECT(image4 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    vx_node nodea = vxOrNode(graph, image2, image2, image4);
+    EXPECT_VX_REFERENCE(nodea);
+    vx_node nodeb = createUserNode(graph, image1, image2);
+    EXPECT_VX_REFERENCE(nodeb);
+    vx_node nodec = vxNotNode(graph, image1, image2);
+    EXPECT_VX_REFERENCE(nodec);
+    vx_node noded = vxNotNode(graph, image2, image3);
+    EXPECT_VX_REFERENCE(noded);
+    writeImage(image1);
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, vxProcessGraph(graph));
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, checkImage(image3, 255, 254) || checkImage(image4, 0, 1));
+    VX_CALL(vxReleaseNode(&nodea));
+    VX_CALL(vxReleaseNode(&nodeb));
+    VX_CALL(vxReleaseNode(&nodec));
+    VX_CALL(vxReleaseNode(&noded));
+    VX_CALL(vxReleaseImage(&image1));
+    VX_CALL(vxReleaseImage(&image2));
+    VX_CALL(vxReleaseImage(&image3));
+    VX_CALL(vxReleaseImage(&image4));
+    VX_CALL(vxReleaseGraph(&graph));
+}
+
+/* Create a test graph and check operation, especially execution order */
+void checkGraphExecution(vx_context context)
+{
+    vx_graph graph;
+    vx_image image1, image2, image3;
+
+    ASSERT_VX_OBJECT(graph = vxCreateGraph(context), VX_TYPE_GRAPH);
+    ASSERT_VX_OBJECT(image1 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    ASSERT_VX_OBJECT(image2 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    ASSERT_VX_OBJECT(image3 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    vx_node nodeb = createUserNode(graph, image1, image2);
+    EXPECT_VX_REFERENCE(nodeb);
+    vx_node nodec = vxNotNode(graph, image1, image2);
+    EXPECT_VX_REFERENCE(nodec);
+    vx_node noded = vxAddNode(graph, image2, image1, VX_CONVERT_POLICY_WRAP, image3);
+    EXPECT_VX_REFERENCE(noded);
+    writeImage(image1);
+    writeImage(image2);
+    writeImage(image3);
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, vxVerifyGraph(graph));
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, vxProcessGraph(graph));
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, checkImage(image1, 1, 2));         /* Image1 should be unchanged */
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, checkImage(image2, 0, 1));       /* Image2 should have been written by output before it was updated */
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, checkImage(image3, 1, 3));       /* Image2 should have been written and updated before being used as an input */
+    VX_CALL(vxReleaseNode(&nodeb));
+    VX_CALL(vxReleaseNode(&nodec));
+    VX_CALL(vxReleaseNode(&noded));
+    VX_CALL(vxReleaseImage(&image1));
+    VX_CALL(vxReleaseImage(&image2));
+    VX_CALL(vxReleaseImage(&image3));
+    VX_CALL(vxReleaseGraph(&graph));
+}
+
+/* Create a test graph and check operation with graph parameters */
+void checkGraphParameters(vx_context context)
+{
+    /*
+    [REQ-BP10] A bidirectional parameter may be added as a graph parameter.
+    In this case the effective direction of the parameter depends upon the graph configuration and rules determining the execution order of the nodes:
+        The edge is connected between an output parameter of node A, a bidirectional parameter of node B, and any number of inputs.
+           In this case the graph parameter is effectively an output, becoming "written" after node B has executed.
+            This is the case whether the graph parameter was created as attached to node A or to node B.
+            If this is confusing, please use a Copy node for clarity, and understand the order of execution of the nodes.
+        The edge is not connected to any output parameter, but to one bidirectional parameter of node A and any number of inputs to other nodes.
+            In this case the graph parameter is truly bidirectional, being at first an input to the node A, and becoming "written" after node A has executed.
+    */
+    vx_graph graph;
+    vx_image image1, image2, image3;
+
+    ASSERT_VX_OBJECT(graph = vxCreateGraph(context), VX_TYPE_GRAPH);
+    ASSERT_VX_OBJECT(image1 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    ASSERT_VX_OBJECT(image2 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    ASSERT_VX_OBJECT(image3 = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    vx_node nodeb = createUserNode(graph, image1, image2);
+    EXPECT_VX_REFERENCE(nodeb);
+    writeImage(image1);
+    writeImage(image2);
+    writeImage(image3);
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, addParameterToGraph(graph, nodeb, 1));   /* Parameter 0 of the graph is the bidirectional parameter */
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, vxVerifyGraph(graph));                   /* Should verify */
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, vxProcessGraph(graph));
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, checkImage(image1, 1, 2));                 /* Image1 should be unchanged */
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, checkImage(image2, 3, 6));                 /* Image2 should have these new values */
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, vxSetGraphParameterByIndex(graph, 0, (vx_reference)image3)); /* Replace image 2 by image 3, should be allowed */
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, vxProcessGraph(graph));                    /* Should be no need to verify again */
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, checkImage(image2, 3, 6));               /* Image2 should not have been modified this time */
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, checkImage(image3, 3, 6));               /* But image3 should have been modified */
+    VX_CALL(vxReleaseNode(&nodeb));
+    VX_CALL(vxReleaseImage(&image1));
+    VX_CALL(vxReleaseImage(&image2));
+    VX_CALL(vxReleaseImage(&image3));
+    VX_CALL(vxReleaseGraph(&graph));
+}
+
+void checkGraphPipelining(vx_context context)
+{
+    /*
+    [REQ-BP11] A bidirectional parameter, whether effectively an output or truly bidirectional (see above),
+     will not become ready for dequeueing until all the nodes to which it is connected have executed.
+
+     Use a graph with one graph parameter connected to a bidirectional and an input, one connected to a
+     bidirectional and an output, one connected to a bidirectional, an output and an input,
+     and one connected to an input. Run through a 3-deep pipeline and check the values.
+     Does nothing unless the pipelining extension is present.
+    */
+  #ifdef OPENVX_KHR_PIPELINING
+    vx_graph graph;
+    ASSERT_VX_OBJECT(graph = vxCreateGraph(context), VX_TYPE_GRAPH);
+    typedef vx_image image3[3]; /* for clarity */
+    image3 images[5];
+    for (int i = 0; i < 5; ++i)
+        for (int j = 0; j < 3; ++j)
+        {
+            images[i][j] = vxCreateImage(context, 2, 2, VX_DF_IMAGE_U8);
+            if (i < 3 ) writeImage(images[i][j]);
+        }
+    vx_node nodes[6] = {
+        createUserNode(graph, images[0][0], images[1][0]),
+        createUserNode(graph, images[0][0], images[2][0]),
+        createUserNode(graph, images[0][0], images[3][0]),
+        vxNotNode(graph, images[1][0], images[2][0]),
+        vxNotNode(graph, images[0][0], images[3][0]),
+        vxNotNode(graph, images[3][0], images[4][0]),
+    };
+    for (int i = 3; i < 6; ++i)
+    {
+        /* We want to test that things are executed in sequence even if parallelised */
+        VX_CALL(vxSetNodeTarget(nodes[i], VX_TARGET_STRING, TIVX_TARGET_DSP1));
+    }
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, addParameterToGraph(graph, nodes[0], 0U));    /* Images[0][], Input only */
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, addParameterToGraph(graph, nodes[0], 1U));    /* Images[1][], Bidirectional */
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, addParameterToGraph(graph, nodes[1], 1U));    /* Images[2][], Effectively an output */
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, addParameterToGraph(graph, nodes[5], 1U));    /* Images[4][], Output only */
+    /* set up pipelining */
+    vx_graph_parameter_queue_params_t graph_params[5] =
+    {
+        {.graph_parameter_index = 0U, .refs_list_size = 3U, .refs_list = (vx_reference *)&images[0][0]},
+        {.graph_parameter_index = 1U, .refs_list_size = 3U, .refs_list = (vx_reference *)&images[1][0]},
+        {.graph_parameter_index = 2U, .refs_list_size = 3U, .refs_list = (vx_reference *)&images[2][0]},
+        {.graph_parameter_index = 3U, .refs_list_size = 3U, .refs_list = (vx_reference *)&images[4][0]}
+    };
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, vxSetGraphScheduleConfig(graph, VX_GRAPH_SCHEDULE_MODE_QUEUE_AUTO, 4, graph_params));
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, vxVerifyGraph(graph));
+    /* At this point we want to output the graph information */
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, tivxExportGraphToDot(graph, "./", "BP11"));
+
+    /* Initial pixels values for all images are (1,2) here we calculate what they should be after execution */
+    vx_uint8 pixels[4][2] =
+    {
+        {1, 2},
+        {3, 6},
+        {0xFE, 0xFD},
+        {0xFF, 0xFE}
+    };
+
+    for (int j = 0; j < 4; ++j) {
+        EXPECT_EQ_VX_STATUS(VX_SUCCESS, vxGraphParameterEnqueueReadyRef(graph, j, graph_params[j].refs_list, 3));
+    }
+
+    for(int i = 0; i < 3; ++i)
+    {
+        vx_image params[5];
+        char label[8];
+        for (int j = 0; j < 4; ++j)
+        {
+            vx_uint32 num_refs = 0;
+            vx_uint32 timer = 200;
+            while (0 == num_refs && --timer > 0)
+            {
+                if (0 == num_refs)
+                    EXPECT_EQ_VX_STATUS(VX_SUCCESS, vxGraphParameterCheckDoneRef(graph, j, &num_refs));
+                if (num_refs)
+                {
+                    EXPECT_EQ_VX_STATUS(VX_SUCCESS, vxGraphParameterDequeueDoneRef(graph, j, (vx_reference *)&params[j], 1, &num_refs));
+                    EXPECT_EQ_VX_STATUS(VX_SUCCESS, checkImage(params[j], pixels[j][0], pixels[j][1]));
+                    break;
+                }
+                else
+                    tivxTaskWaitMsecs(100);
+            }
+            if (0 == timer)
+            {
+                FAIL(label);
+            }
+        }
+    }
+
+    for (int i = 0; i < 5; ++i)
+        for (int j = 0; j < 3; ++j)
+            VX_CALL(vxReleaseImage(&images[i][j]));
+    for (int i = 0; i < 6; ++i)
+        VX_CALL(vxReleaseNode(&nodes[i]));
+    VX_CALL(vxReleaseGraph(&graph));
+  #else
+    printf("Pipelining is not implemented\n");
+  #endif
+}
+
+/* Check replication works with object array, and that it fails unless bidirectional parameters are replicated */
+void checkGraphReplicationArray(vx_context context)
+{
+    vx_graph graph;
+    vx_image image, input, bidir0, bidir1;
+    vx_object_array inp_array, bid_array;
+
+    ASSERT_VX_OBJECT(graph = vxCreateGraph(context), VX_TYPE_GRAPH);
+    ASSERT_VX_OBJECT(image = vxCreateImage(context, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    ASSERT_VX_OBJECT(inp_array = vxCreateObjectArray(context, (vx_reference)image, 3), VX_TYPE_OBJECT_ARRAY);
+    ASSERT_VX_OBJECT(bid_array = vxCreateObjectArray(context, (vx_reference)image, 3), VX_TYPE_OBJECT_ARRAY);
+    VX_CALL(vxReleaseImage(&image));
+    input = (vx_image)vxGetObjectArrayItem(inp_array, 0);
+    bidir0 = (vx_image)vxGetObjectArrayItem(bid_array, 0);
+    bidir1 = (vx_image)vxGetObjectArrayItem(bid_array, 1);
+    vx_node node = createUserNode(graph, input, bidir0);
+    EXPECT_VX_REFERENCE(node);
+    vx_bool replicate[2] = {vx_false_e, vx_false_e};
+    EXPECT_NE_VX_STATUS(VX_SUCCESS, vxReplicateNode(graph, node, replicate, 2));
+    replicate[1] = vx_true_e;
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, vxReplicateNode(graph, node, replicate, 2));
+    writeImage(input);
+    writeImage(bidir0);
+    writeImage(bidir1);
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, vxVerifyGraph(graph));
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, vxProcessGraph(graph));
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, checkImage(bidir0, 3, 6));
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, checkImage(bidir1, 3, 6));
+    VX_CALL(vxRemoveNode(&node));
+    VX_CALL(vxReleaseImage(&input));
+    VX_CALL(vxReleaseImage(&bidir0));
+    VX_CALL(vxReleaseImage(&bidir1));
+    VX_CALL(vxReleaseObjectArray(&inp_array));
+    VX_CALL(vxReleaseObjectArray(&bid_array));
+    VX_CALL(vxReleaseGraph(&graph));
+}
+
+/* Check replication works with pyramids */
+void checkGraphReplicationPyramid(vx_context context)
+{
+    vx_graph graph;
+    vx_pyramid inp_pyramid, bid_pyramid;
+
+    ASSERT_VX_OBJECT(graph = vxCreateGraph(context), VX_TYPE_GRAPH);
+    ASSERT_VX_OBJECT(inp_pyramid = vxCreatePyramid(context, 2, VX_SCALE_PYRAMID_HALF, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_PYRAMID);
+    ASSERT_VX_OBJECT(bid_pyramid = vxCreatePyramid(context, 2, VX_SCALE_PYRAMID_HALF, 100, 100, VX_DF_IMAGE_U8), VX_TYPE_PYRAMID);
+    vx_image input0 = vxGetPyramidLevel(inp_pyramid, 0);
+    vx_image input1 = vxGetPyramidLevel(inp_pyramid, 1);
+    vx_image bidir0 = vxGetPyramidLevel(bid_pyramid, 0);
+    vx_image bidir1 = vxGetPyramidLevel(bid_pyramid, 1);
+    vx_node node = createUserNode(graph, input0, bidir0);
+    EXPECT_VX_REFERENCE(node);
+    vx_bool replicate[2] = {vx_true_e, vx_true_e};
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, vxReplicateNode(graph, node, replicate, 2));
+    writeImage(input0);
+    writeImage(input1);
+    writeImage(bidir0);
+    writeImage(bidir1);
+    VX_CALL(vxVerifyGraph(graph));
+    VX_CALL(vxProcessGraph(graph));
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, checkImage(bidir0, 3, 6));
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, checkImage(bidir1, 3, 6));
+    VX_CALL(vxReleaseNode(&node));
+    VX_CALL(vxReleasePyramid(&inp_pyramid));
+    VX_CALL(vxReleasePyramid(&bid_pyramid));
+    VX_CALL(vxReleaseImage(&input0));
+    VX_CALL(vxReleaseImage(&bidir0));
+    VX_CALL(vxReleaseImage(&input1));
+    VX_CALL(vxReleaseImage(&bidir1));
+    VX_CALL(vxReleaseGraph(&graph));
+}
+
+
+TEST(bpExtFramework, testGraphbidirFail)
+{
+    /* Graphs that should fail */
+    vx_context context = context_->vx_context_;
+    registerUserKernel(context);
+    makeGraph1O2B2I(context);           /* BP03 */
+    makeGraph2B2I(context);
+    makeGraph1O2B(context);
+    makeGraph2B(context);
+    makeGraphV1O2B1I(context);          /* BP04 */
+    makeGraphV1B1I(context);
+    makeGraphV1O1B(context);
+    makeGraphV1B(context);
+    makeGraphCycle0(context);           /* BP05 */
+    makeGraphUniform(context);          /* BP06 */
+    makeGraphCycle1(context);           /* BP09 */
+    makeGraphCycle2(context);           /* BP09 */
+    unRegisterUserKernel(context);
+}
+
+TEST(bpExtFramework, testGraphbidirSuccess)
+{
+    vx_context context = context_->vx_context_;
+    registerUserKernel(context);
+    makeGraph1O1B2I(context);           /* BP03 */
+    makeGraph1B2I(context);
+    makeGraph1O1B(context);
+    makeGraph1B(context);
+    makeGraphV1O1B1I(context);          /* BP04 */
+    makeGraphV1O1B3I(context);
+    unRegisterUserKernel(context);
+}
+
+TEST(bpExtFramework, testGraphbidirExOrder)
+{
+    vx_context context = context_->vx_context_;
+    registerUserKernel(context);
+    checkGraphExecution(context);       /* BP07, BO08 */
+    unRegisterUserKernel(context);
+}
+
+TEST(bpExtFramework, testGraphbidirGraphParam)
+{
+    vx_context context = context_->vx_context_;
+    registerUserKernel(context);
+    checkGraphParameters(context);      /* BP10 */
+    unRegisterUserKernel(context);
+}
+
+TEST(bpExtFramework, testGraphbidirReplicate)
+{
+    vx_context context = context_->vx_context_;
+    registerUserKernel(context);
+    checkGraphReplicationArray(context);    /* BP12 a*/
+    checkGraphReplicationPyramid(context);  /* BP12 p*/
+    unRegisterUserKernel(context);
+}
+
+TEST(bpExtFramework, testGraphbidirPipelining)
+{
+    vx_context context = context_->vx_context_;
+    registerUserKernel(context);
+    checkGraphPipelining(context);      /* BP11 */
+    unRegisterUserKernel(context);
+}
+
+TESTCASE_TESTS(bpExtFramework,
+        testGraphbidirFail,
+        testGraphbidirSuccess,
+        testGraphbidirExOrder,
+        testGraphbidirGraphParam,
+        testGraphbidirReplicate,
+        testGraphbidirPipelining)

--- a/conformance_tests/test_tiovx/test_bidir_ext_standardnode.c
+++ b/conformance_tests/test_tiovx/test_bidir_ext_standardnode.c
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2013-2023 The Khronos Group Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "test_engine/test.h"
+#include "test_tiovx/test_tiovx.h"
+
+#include <VX/vx.h>
+#include <TI/tivx.h>
+#include <VX/vx_khr_bidirectional_parameters.h>
+
+TESTCASE(bpExtStandardNodes, CT_VXContext, ct_setup_vx_context, 0)
+
+/* Write some data on an 8-bit image */
+void bd_std_node_writeImage(vx_image image, vx_uint8 a, vx_uint8 b)
+{
+    vx_map_id id;
+    vx_rectangle_t rect = {.start_x = 0, .end_x = 1, .start_y = 0, .end_y = 2};
+    vx_imagepatch_addressing_t ipa;
+    void *ptr;
+    VX_CALL(vxMapImagePatch(image, &rect, 0, &id, &ipa, &ptr, VX_READ_AND_WRITE, VX_MEMORY_TYPE_HOST, 0));
+    *(vx_uint8 *)vxFormatImagePatchAddress2d(ptr, 0, 0, &ipa) = a;
+    *(vx_uint8 *)vxFormatImagePatchAddress2d(ptr, 0, 1, &ipa) = b;
+    VX_CALL(vxUnmapImagePatch(image, id));
+}
+
+/* Check data in an 8-bit image */
+vx_status bd_std_node_checkImage(vx_image image, vx_uint8 a, vx_uint8 b)
+{
+    vx_status status = (vx_status)VX_SUCCESS;
+    vx_map_id id;
+    vx_rectangle_t rect = {.start_x = 0, .end_x = 1, .start_y = 0, .end_y = 2};
+    vx_imagepatch_addressing_t ipa;
+    void *ptr;
+    status = vxMapImagePatch(image, &rect, 0, &id, &ipa, &ptr, VX_READ_AND_WRITE, VX_MEMORY_TYPE_HOST, 0);
+    if (status != (vx_status)VX_SUCCESS)
+    {
+        return status;
+    }
+    vx_uint8 aa = *(vx_uint8 *)vxFormatImagePatchAddress2d(ptr, 0, 0, &ipa);
+    vx_uint8 bb = *(vx_uint8 *)vxFormatImagePatchAddress2d(ptr, 0, 1, &ipa);
+    status = vxUnmapImagePatch(image, id);
+    if (status != (vx_status)VX_SUCCESS)
+    {
+        return status;
+    }
+    /* On failure return a non-zero value encoding the pixels, easily readable in decimal */
+    return (aa == a) && (bb  == b) ? status : aa * 1000 + bb + 1000000;
+}
+
+/* Write some data on a 16-bit image */
+void bd_std_node_writeImageS16(vx_image image, vx_int16 a, vx_int16 b)
+{
+    vx_map_id id;
+    vx_rectangle_t rect = {.start_x = 0, .end_x = 1, .start_y = 0, .end_y = 2};
+    vx_imagepatch_addressing_t ipa;
+    void *ptr;
+    VX_CALL(vxMapImagePatch(image, &rect, 0, &id, &ipa, &ptr, VX_READ_AND_WRITE, VX_MEMORY_TYPE_HOST, 0));
+    *(vx_int16 *)vxFormatImagePatchAddress2d(ptr, 0, 0, &ipa) = a;
+    *(vx_int16 *)vxFormatImagePatchAddress2d(ptr, 0, 1, &ipa) = b;
+    VX_CALL(vxUnmapImagePatch(image, id));
+}
+
+/* Check data in an 8-bit image */
+vx_status checkImageS16(vx_image image, vx_int16 a, vx_int16 b)
+{
+    vx_status status = (vx_status)VX_SUCCESS;
+    vx_map_id id;
+    vx_rectangle_t rect = {.start_x = 0, .end_x = 1, .start_y = 0, .end_y = 2};
+    vx_imagepatch_addressing_t ipa;
+    void *ptr;
+    status = vxMapImagePatch(image, &rect, 0, &id, &ipa, &ptr, VX_READ_AND_WRITE, VX_MEMORY_TYPE_HOST, 0);
+    if (status != (vx_status)VX_SUCCESS)
+    {
+        return status;
+    }
+    vx_int16 aa = *(vx_int16 *)vxFormatImagePatchAddress2d(ptr, 0, 0, &ipa);
+    vx_int16 bb = *(vx_int16 *)vxFormatImagePatchAddress2d(ptr, 0, 1, &ipa);
+    status = vxUnmapImagePatch(image, id);
+    if (status != (vx_status)VX_SUCCESS)
+    {
+        return status;
+    }
+    /* On failure output the data and return VX_FAILURE */
+    if (aa == a && bb == b)
+        return status;
+    return VX_FAILURE;
+}
+
+vx_status releaseNode(vx_node node)
+{
+    return vxReleaseNode(&node);
+}
+
+void testAccumulate(vx_context context)
+{
+    vx_graph graph;
+    vx_image in_param, accum_param;
+
+    ASSERT_VX_OBJECT(graph = vxCreateGraph(context), VX_TYPE_GRAPH);
+    ASSERT_VX_OBJECT(in_param = vxCreateImage(context, 8, 8, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    ASSERT_VX_OBJECT(accum_param = vxCreateImage(context, 8, 8, VX_DF_IMAGE_S16), VX_TYPE_IMAGE);
+    bd_std_node_writeImage(in_param, 0x01, 0xFF);
+    bd_std_node_writeImageS16(accum_param, 0x0100, 0x7F03);
+    VX_CALL(releaseNode(vxAccumulateImageNode(graph, in_param, accum_param)));
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, vxProcessGraph(graph));
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, checkImageS16(accum_param, 0x0101, 0x7FFF));
+    VX_CALL(vxReleaseImage(&in_param));
+    VX_CALL(vxReleaseImage(&accum_param));
+    VX_CALL(vxReleaseGraph(&graph));
+}
+
+void testAccumulateBad(vx_context context)
+{
+    vx_graph graph;
+    vx_image in_param, accum_param;
+
+    ASSERT_VX_OBJECT(graph = vxCreateGraph(context), VX_TYPE_GRAPH);
+    ASSERT_VX_OBJECT(in_param = vxCreateImage(context, 8, 8, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    ASSERT_VX_OBJECT(accum_param  = vxCreateImage(context, 8, 8, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    bd_std_node_writeImage(in_param, 0x01, 0xFF);
+    bd_std_node_writeImage(accum_param, 0xFF, 0x03);
+    vx_node node = vxAccumulateImageNode(graph, NULL, accum_param);
+    EXPECT_NE_VX_STATUS(VX_SUCCESS, vxGetStatus((vx_reference)node));
+    VX_CALL(releaseNode(vxAccumulateImageNode(graph, in_param, accum_param)));
+    EXPECT_NE_VX_STATUS(VX_SUCCESS, vxVerifyGraph(graph));
+    VX_CALL(vxReleaseImage(&in_param));
+    VX_CALL(vxReleaseImage(&accum_param));
+    VX_CALL(vxReleaseGraph(&graph));
+}
+
+void testAccumulateSquare(vx_context context)
+{
+    vx_graph graph;
+    vx_image in_param, accum_param;
+
+    ASSERT_VX_OBJECT(graph = vxCreateGraph(context), VX_TYPE_GRAPH);
+    ASSERT_VX_OBJECT(in_param = vxCreateImage(context, 8, 8, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    ASSERT_VX_OBJECT(accum_param = vxCreateImage(context, 8, 8, VX_DF_IMAGE_S16), VX_TYPE_IMAGE);
+    bd_std_node_writeImage(in_param, 04, 0xFF);
+    bd_std_node_writeImageS16(accum_param, 100, 0x7F03);
+    VX_CALL(releaseNode(vxAccumulateSquareImageNodeX(graph, in_param, 0, accum_param)));
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, vxProcessGraph(graph));
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, checkImageS16(accum_param, 116, 0x7FFF));
+    VX_CALL(vxReleaseImage(&in_param));
+    VX_CALL(vxReleaseImage(&accum_param));
+    VX_CALL(vxReleaseGraph(&graph));
+}
+
+void testAccumulateSquareBad(vx_context context)
+{
+    vx_graph graph;
+    vx_image in_param, accum_param;
+
+    ASSERT_VX_OBJECT(graph = vxCreateGraph(context), VX_TYPE_GRAPH);
+    ASSERT_VX_OBJECT(in_param = vxCreateImage(context, 8, 8, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    ASSERT_VX_OBJECT(accum_param = vxCreateImage(context, 8, 8, VX_DF_IMAGE_S16), VX_TYPE_IMAGE);
+    bd_std_node_writeImage(in_param, 0x01, 0xFF);
+    bd_std_node_writeImageS16(accum_param, 0xFF, 0x03);
+    vx_node node = vxAccumulateSquareImageNodeX(graph, in_param, 0, NULL);
+    EXPECT_NE_VX_STATUS(VX_SUCCESS, vxGetStatus((vx_reference)node));
+    VX_CALL(releaseNode(vxAccumulateSquareImageNodeX(graph, in_param, 17, accum_param)));
+    EXPECT_NE_VX_STATUS(VX_SUCCESS, vxVerifyGraph(graph));
+    VX_CALL(vxReleaseImage(&in_param));
+    VX_CALL(vxReleaseImage(&accum_param));
+    VX_CALL(vxReleaseGraph(&graph));
+}
+
+void testAccumulateWeighted(vx_context context)
+{
+    vx_graph graph;
+    vx_image in_param, accum_param;
+
+    ASSERT_VX_OBJECT(graph = vxCreateGraph(context), VX_TYPE_GRAPH);
+    ASSERT_VX_OBJECT(in_param = vxCreateImage(context, 8, 8, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    ASSERT_VX_OBJECT(accum_param = vxCreateImage(context, 8, 8, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+
+    bd_std_node_writeImage(in_param, 04, 100);
+    bd_std_node_writeImage(accum_param, 100, 200);
+    VX_CALL(releaseNode(vxAccumulateWeightedImageNodeX(graph, in_param, 0.25f, accum_param)));
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, vxProcessGraph(graph));
+    EXPECT_EQ_VX_STATUS(VX_SUCCESS, bd_std_node_checkImage(accum_param, 76, 175));
+    VX_CALL(vxReleaseImage(&in_param));
+    VX_CALL(vxReleaseImage(&accum_param));
+    VX_CALL(vxReleaseGraph(&graph));
+}
+
+void testAccumulateWeightedBad(vx_context context)
+{
+    vx_graph graph;
+    vx_image in_param, accum_param;
+
+    ASSERT_VX_OBJECT(graph = vxCreateGraph(context), VX_TYPE_GRAPH);
+    ASSERT_VX_OBJECT(in_param = vxCreateImage(context, 8, 8, VX_DF_IMAGE_U8), VX_TYPE_IMAGE);
+    ASSERT_VX_OBJECT(accum_param = vxCreateImage(context, 8, 8, VX_DF_IMAGE_S16), VX_TYPE_IMAGE);
+
+    bd_std_node_writeImage(in_param, 0x01, 0xFF);
+    bd_std_node_writeImageS16(accum_param, 0xFF, 0x03);
+    vx_node node = vxAccumulateWeightedImageNodeX(graph, in_param, 0.2f, NULL);
+    EXPECT_NE_VX_STATUS(VX_SUCCESS, vxGetStatus((vx_reference)node));
+    VX_CALL(releaseNode(vxAccumulateWeightedImageNodeX(graph, in_param, 1.5f, accum_param)));
+    EXPECT_NE_VX_STATUS(VX_SUCCESS, vxVerifyGraph(graph));
+    VX_CALL(vxReleaseImage(&in_param));
+    VX_CALL(vxReleaseImage(&accum_param));
+    VX_CALL(vxReleaseGraph(&graph));
+}
+
+TEST(bpExtStandardNodes, testbidirAccumulatedNodeGood)
+{
+    vx_context context = context_->vx_context_;
+    testAccumulate(context);
+    testAccumulateSquare(context);
+    testAccumulateWeighted(context);
+}
+
+TEST(bpExtStandardNodes, testbidirAccumulatedNodeFail)
+{
+    vx_context context = context_->vx_context_;
+    testAccumulateBad(context);
+    testAccumulateSquareBad(context);
+    testAccumulateWeightedBad(context);
+}
+
+TESTCASE_TESTS(bpExtStandardNodes,
+                testbidirAccumulatedNodeFail,
+                testbidirAccumulatedNodeGood)

--- a/conformance_tests/test_tiovx/test_main.h
+++ b/conformance_tests/test_tiovx/test_main.h
@@ -115,4 +115,6 @@ TESTCASE(tivxObjDesc)
 TESTCASE(tivxNestedUserNode)
 #endif
 TESTCASE(tivxTgKnl)
+TESTCASE(bpExtStandardNodes)
+TESTCASE(bpExtFramework)
 #endif

--- a/include/TI/tivx.h
+++ b/include/TI/tivx.h
@@ -66,6 +66,7 @@
 #include <VX/vx.h>
 #include <VX/vx_khr_pipelining.h>
 #include <VX/vx_khr_user_data_object.h>
+#include <VX/vx_khr_bidirectional_parameters.h>
 #include <TI/tivx_debug.h>
 #include <TI/tivx_log_rt.h>
 #include <TI/tivx_kernels.h>

--- a/include/VX/vx_khr_bidirectional_parameters.h
+++ b/include/VX/vx_khr_bidirectional_parameters.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2023 The Khronos Group Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _OPENVX_BIDIRECTIONAL_H_
+#define _OPENVX_BIDIRECTIONAL_H_
+
+/*!
+ * \file
+ * \brief The OpenVX Bidirectional Parameters extension API.
+ */
+
+#define OPENVX_KHR_BIDIRECTIONAL_PARAMETERS  "vx_khr_bidirectional_parameters"
+
+#define OPENVX_KHR_BIDIRECTIONAL_OPTIONAL_KERNELS /* Remove if optional kernels are not implemented */
+
+#include <VX/vx.h>
+
+#ifdef  __cplusplus
+extern "C" {
+#endif
+
+/*! \brief Extra enums.
+ *
+ * \ingroup group_parameter
+ */
+
+enum vx_bidirectional_enum_e
+{
+    VX_BIDIRECTIONAL = VX_ENUM_BASE(VX_ID_KHRONOS, VX_ENUM_DIRECTION) + 0x2 /* Additional parameter direction enumeration */
+};
+
+#ifdef OPENVX_KHR_BIDIRECTIONAL_OPTIONAL_KERNELS
+/*! \brief [Graph] Creates an accumulate node.
+ * \param [in] graph The reference to the graph.
+ * \param [in] input The input <tt>\ref VX_DF_IMAGE_U8</tt> image.
+ * \param [in,out] accum The accumulation image in <tt>\ref VX_DF_IMAGE_S16</tt>.
+ * \ingroup group_vision_function_accumulate
+ * \return <tt>\ref vx_node</tt>.
+ * \retval vx_node A node reference. Any possible errors preventing a successful creation should be checked using <tt>\ref vxGetStatus</tt>  
+ */
+VX_API_ENTRY vx_node VX_API_CALL vxAccumulateImageNode(vx_graph graph, vx_image input, vx_image accum);
+
+/*! \brief [Graph] Creates a weighted accumulate node.
+ * \param [in] graph The reference to the graph.
+ * \param [in] input The input <tt>\ref VX_DF_IMAGE_U8</tt> image.
+ * \param [in] alpha The input <tt>\ref VX_TYPE_FLOAT32</tt> scalar value with a value in the range of \f$ 0.0 \le \alpha \le 1.0 \f$.
+ * \param [in,out] accum The <tt>\ref VX_DF_IMAGE_U8</tt> accumulation image.
+ * \ingroup group_vision_function_accumulate_weighted
+ * \return <tt>\ref vx_node</tt>.
+ * \retval vx_node A node reference. Any possible errors preventing a successful creation should be checked using <tt>\ref vxGetStatus</tt>  
+ */
+VX_API_ENTRY vx_node VX_API_CALL vxAccumulateWeightedImageNodeX(vx_graph graph, vx_image input, vx_float32 alpha, vx_image accum);
+
+/*! \brief [Graph] Creates an accumulate square node.
+ * \param [in] graph The reference to the graph.
+ * \param [in] input The input <tt>\ref VX_DF_IMAGE_U8</tt> image.
+ * \param [in] shift The input <tt>\ref VX_TYPE_UINT32</tt> with a value in the range of \f$ 0 \le shift \le 15 \f$.
+ * \param [in,out] accum The accumulation image in <tt>\ref VX_DF_IMAGE_S16</tt>.
+ * \ingroup group_vision_function_accumulate_square
+ * \return <tt>\ref vx_node</tt>.
+ * \retval vx_node A node reference. Any possible errors preventing a successful creation should be checked using <tt>\ref vxGetStatus</tt>  
+ */
+VX_API_ENTRY vx_node VX_API_CALL vxAccumulateSquareImageNodeX(vx_graph graph, vx_image input, vx_uint32 shift, vx_image accum);
+#endif
+
+#ifdef  __cplusplus
+}
+#endif
+
+#endif

--- a/include/VX/vx_types.h
+++ b/include/VX/vx_types.h
@@ -564,9 +564,7 @@ enum vx_direction_e {
     /*! \brief The parameter is an input only. */
     VX_INPUT = VX_ENUM_BASE(VX_ID_KHRONOS, VX_ENUM_DIRECTION) + 0x0,
     /*! \brief The parameter is an output only. */
-    VX_OUTPUT = VX_ENUM_BASE(VX_ID_KHRONOS, VX_ENUM_DIRECTION) + 0x1,
-    /*! \brief The parameter is both an input and output. */
-    VX_BIDIRECTIONAL = VX_ENUM_BASE(VX_ID_KHRONOS, VX_ENUM_DIRECTION) + 0x2,
+    VX_OUTPUT = VX_ENUM_BASE(VX_ID_KHRONOS, VX_ENUM_DIRECTION) + 0x1
 };
 
 /*! \brief These enumerations are given to the <tt>\ref vxHint</tt> API to enable/disable platform

--- a/kernels/openvx-core/host/vx_accumulate_host.c
+++ b/kernels/openvx-core/host/vx_accumulate_host.c
@@ -258,7 +258,7 @@ vx_status tivxAddKernelAccumulate(vx_context context)
         {
             status = vxAddParameterToKernel(kernel,
                         index,
-                        (vx_enum)VX_OUTPUT,
+                        (vx_enum)VX_BIDIRECTIONAL,
                         (vx_enum)VX_TYPE_IMAGE,
                         (vx_enum)VX_PARAMETER_STATE_REQUIRED
             );

--- a/kernels/openvx-core/host/vx_accumulate_square_host.c
+++ b/kernels/openvx-core/host/vx_accumulate_square_host.c
@@ -297,7 +297,7 @@ vx_status tivxAddKernelAccumulateSquare(vx_context context)
         {
             status = vxAddParameterToKernel(kernel,
                         index,
-                        (vx_enum)VX_OUTPUT,
+                        (vx_enum)VX_BIDIRECTIONAL,
                         (vx_enum)VX_TYPE_IMAGE,
                         (vx_enum)VX_PARAMETER_STATE_REQUIRED
             );

--- a/kernels/openvx-core/host/vx_accumulate_weighted_host.c
+++ b/kernels/openvx-core/host/vx_accumulate_weighted_host.c
@@ -297,7 +297,7 @@ vx_status tivxAddKernelAccumulateWeighted(vx_context context)
         {
             status = vxAddParameterToKernel(kernel,
                         index,
-                        (vx_enum)VX_OUTPUT,
+                        (vx_enum)VX_BIDIRECTIONAL,
                         (vx_enum)VX_TYPE_IMAGE,
                         (vx_enum)VX_PARAMETER_STATE_REQUIRED
             );

--- a/source/framework/vx_graph_pipeline.c
+++ b/source/framework/vx_graph_pipeline.c
@@ -1044,7 +1044,7 @@ void ownGraphDetectAndSetNumBuf(vx_graph graph)
                     ref = ownNodeGetParameterRef(node_cur, prm_cur_idx);
                     prm_dir = (uint32_t)ownNodeGetParameterDir(node_cur, prm_cur_idx);
 
-                    if( (ref!=NULL) && ((vx_enum)prm_dir == VX_OUTPUT)) /* ref could be NULL due to optional parameters */
+                    if( (ref!=NULL) && ((vx_enum)prm_dir !=  (vx_enum)VX_INPUT)) /* ref could be NULL due to optional parameters */
                     {
                         is_ref_graph_param = (vx_bool)vx_false_e;
 

--- a/source/framework/vx_meta_format.c
+++ b/source/framework/vx_meta_format.c
@@ -1293,7 +1293,7 @@ static vx_bool ownIsMetaFormatRawImageEqual(
                 is_equal = (vx_bool)vx_true_e;
             }
         }
-        else
+        if ((vx_bool)vx_false_e == is_equal)
         {
             VX_PRINT(VX_ZONE_INFO, "Raw Image object meta data are not equivalent!\n");
         }

--- a/source/framework/vx_node_api.c
+++ b/source/framework/vx_node_api.c
@@ -500,6 +500,14 @@ VX_API_ENTRY vx_node VX_API_CALL vxAccumulateWeightedImageNode(vx_graph graph, v
                                    dimof(params));
 }
 
+VX_API_ENTRY vx_node VX_API_CALL vxAccumulateWeightedImageNodeX(vx_graph graph, vx_image input, vx_float32 alpha, vx_image accum)
+{
+    vx_scalar salpha = vxCreateScalar(vxGetContext((vx_reference)graph), (vx_enum)VX_TYPE_FLOAT32, &alpha);
+    vx_node node = vxAccumulateWeightedImageNode(graph, input, salpha, accum);
+    vxReleaseScalar(&salpha);
+    return node;
+}
+
 VX_API_ENTRY vx_node VX_API_CALL vxAccumulateSquareImageNode(vx_graph graph, vx_image input, vx_scalar scalar, vx_image accum)
 {
     vx_reference params[] = {
@@ -511,6 +519,14 @@ VX_API_ENTRY vx_node VX_API_CALL vxAccumulateSquareImageNode(vx_graph graph, vx_
                                    (vx_enum)VX_KERNEL_ACCUMULATE_SQUARE,
                                    params,
                                    dimof(params));
+}
+
+VX_API_ENTRY vx_node VX_API_CALL vxAccumulateSquareImageNodeX(vx_graph graph, vx_image input, vx_uint32 shift, vx_image accum)
+{
+    vx_scalar scalar = vxCreateScalar(vxGetContext((vx_reference)graph), (vx_enum)VX_TYPE_UINT32, &shift);
+    vx_node node = vxAccumulateSquareImageNode(graph, input, scalar, accum);
+    vxReleaseScalar(&scalar);
+    return node;
 }
 
 VX_API_ENTRY vx_node VX_API_CALL vxMinMaxLocNode(vx_graph graph,

--- a/source/framework/vx_parameter.c
+++ b/source/framework/vx_parameter.c
@@ -52,7 +52,10 @@ vx_bool ownIsValidDirection(vx_enum dir)
 {
     vx_bool is_valid;
 
-    if ((dir == (vx_enum)VX_INPUT) || (dir == (vx_enum)VX_OUTPUT)) /* Bidirectional is not valid for user kernels */
+    if ((dir == (vx_enum)VX_INPUT) ||
+        (dir == (vx_enum)VX_OUTPUT) ||
+        (dir == (vx_enum)VX_BIDIRECTIONAL) /* Bidirectional is valid for user kernels with the bidirectional parameters extension*/
+       )
     {
         is_valid = (vx_bool)vx_true_e;
     }

--- a/source/framework/vx_target.c
+++ b/source/framework/vx_target.c
@@ -238,6 +238,7 @@ static vx_bool ownTargetNodeDescCanNodeExecute(
                         TIVX_NODE_FLAG_IS_EXECUTED) == (vx_bool)vx_false_e)
             {
                 can_execute = (vx_bool)vx_false_e;
+                break;
             }
         }
     }
@@ -1257,7 +1258,7 @@ vx_status ownTargetCreate(vx_enum target_id, const tivx_target_create_params_t *
                  * as the status check is covered in previous check
                  * in tivxQueueCreate
                  */
-                (void)tivxQueueDelete(&target->job_queue_handle);   
+                (void)tivxQueueDelete(&target->job_queue_handle);
             }
         }
 
@@ -1407,7 +1408,8 @@ void ownTargetSetTimestamp(
     {
         if (NULL != obj_desc[prm_id])
         {
-            if (tivxFlagIsBitSet(is_prm_input_flag, ((uint32_t)1U<<prm_id))==(vx_bool)vx_true_e)
+           if ((tivxFlagIsBitSet(is_prm_input_flag, ((uint32_t)1U<<prm_id))==(vx_bool)vx_true_e) ||
+                (tivxFlagIsBitSet(is_prm_input_flag, ((uint32_t)TIVX_OBJ_DESC_BIDIR_FLAG<<prm_id))==(vx_bool)vx_true_e))
             {
                 obj_timestamp = obj_desc[prm_id]->timestamp;
 

--- a/source/framework/vx_target_acquire_parameters.c
+++ b/source/framework/vx_target_acquire_parameters.c
@@ -373,7 +373,7 @@ static void ownTargetNodeDescReleaseParameter(
 
     flags = data_ref_q_obj_desc->flags;
 
-    if(is_prm_input == (vx_bool)vx_true_e)
+    if((vx_bool)vx_true_e == is_prm_input)
     {
         data_ref_q_obj_desc->in_node_done_cnt++;
         if(data_ref_q_obj_desc->in_node_done_cnt==data_ref_q_obj_desc->num_in_nodes)
@@ -427,7 +427,7 @@ static void ownTargetNodeDescReleaseParameter(
     }
     else
     {
-        /* this is a output and is used as input but some other node */
+        /* this is a output or bidirectional and is used as input by some other node */
         data_ref_q_obj_desc->ref_obj_desc_id = ref_obj_desc_id;
     }
     if((do_release_ref != (vx_bool)vx_false_e) || (do_release_ref_to_queue != (vx_bool)vx_false_e))
@@ -627,9 +627,10 @@ void ownTargetNodeDescReleaseAllParameters(tivx_obj_desc_node_t *node_obj_desc, 
 
             if(0 != ownObjDescIsValidType((tivx_obj_desc_t*)data_ref_q_obj_desc, TIVX_OBJ_DESC_DATA_REF_Q))
             {
-                is_prm_input = tivxFlagIsBitSet(is_prm_input_flag, ((uint32_t)1U<<prm_id));
-
+                is_prm_input =    tivxFlagIsBitSet(is_prm_input_flag, ((uint32_t)1U<<prm_id))
+                               || tivxFlagIsBitSet(is_prm_input_flag, ((uint32_t)TIVX_OBJ_DESC_BIDIR_FLAG<<prm_id));
                 is_prm_released = (vx_bool)vx_false_e;
+
 
                 ownTargetNodeDescReleaseParameter(
                     node_obj_desc,

--- a/source/include/tivx_obj_desc_priv.h
+++ b/source/include/tivx_obj_desc_priv.h
@@ -139,6 +139,10 @@ extern "C" {
 #define TIVX_OBJ_DESC_ID_MASK            (0x0000FFFFu)
 
 
+/*! \brief Mask for storing Object Descriptor id in 32bit variable
+ * \ingroup group_tivx_obj_desc_priv
+ */
+#define TIVX_OBJ_DESC_BIDIR_FLAG         (0x10000U)
 
 
 /*!


### PR DESCRIPTION
the changes are based on the SDK9 delivery (tag 09.00.00.02). You have to create a branch from that branch if you want me to merge on this version.

description
this is the bidirectional parameters for the TI openVX implementation.
please refer to the documentation located in docs/rb_extensions/bidirectional_extension.md for more information.

testing: (updated 09.10.23)
the TI OVX conformance were run with the following results:
OpenVX Conformance report summary
To be conformant to the OpenVX baseline, 7230 required test(s) must pass. 7230 tests passed, 0 tests failed. PASSED.
To be conformant to the User Data Object extension, 14 required test(s) must pass. 14 tests passed, 0 tests failed. PASSED.
Note: The 9822 disabled tests are optional and are not considered for conformance.
