### PR TITLE
Updated the meta structure object member as union

### DIFF
--- a/utils/include/tivx_utils_ipc_ref_xfer.h
+++ b/utils/include/tivx_utils_ipc_ref_xfer.h
@@ -96,95 +96,100 @@ typedef struct
     /*!< \brief The type of meta data */
     vx_enum type;
 
-    /*!< \brief structure containing information about image
-                used when type is set to VX_TYPE_IMAGE */
-    struct {
-        /*!< \brief The width of the image in pixels */
-        vx_uint32 width;
-        /*!< \brief The height of the image in pixels */
-        vx_uint32 height;
-        /*!< \brief The format of the image. */
-        vx_df_image format;
-        /*!< \brief Number of data planes in image */
-        vx_uint32 planes;
-    } img;
+    /*!< \brief Union containing different types of metadata */
+    union {
 
-    struct {
-        /*!< \brief The width of the 0th image in pixels. */
-        vx_uint32 width;
-        /*!< \brief The height of the 0th image in pixels. */
-        vx_uint32 height;
-        /*!< \brief The <tt>\ref vx_df_image_e</tt> format of the image. */
-        vx_df_image format;
-        /*!< \brief The number of scale levels */
-        vx_size levels;
-        /*!< \brief The ratio between each level */
-        vx_float32 scale;
-        /*!< \brief Number of data planes in image */
-        vx_uint32 planes;
-    } pmd;
+        /*!< \brief structure containing information about image
+                    used when type is set to VX_TYPE_IMAGE */
+        struct {
+            /*!< \brief The width of the image in pixels */
+            vx_uint32 width;
+            /*!< \brief The height of the image in pixels */
+            vx_uint32 height;
+            /*!< \brief The format of the image. */
+            vx_df_image format;
+            /*!< \brief Number of data planes in image */
+            vx_uint32 planes;
+        } img;
 
-    /*!< \brief structure containing information about array
-                used when type is set to VX_TYPE_ARRAY */
-    struct {
-        /*!< \brief The type of the Array items */
-        vx_enum item_type;
-        /*!< \brief The capacity of the Array */
-        vx_size capacity;
-    } arr;
+        struct {
+            /*!< \brief The width of the 0th image in pixels. */
+            vx_uint32 width;
+            /*!< \brief The height of the 0th image in pixels. */
+            vx_uint32 height;
+            /*!< \brief The <tt>\ref vx_df_image_e</tt> format of the image. */
+            vx_df_image format;
+            /*!< \brief The number of scale levels */
+            vx_size levels;
+            /*!< \brief The ratio between each level */
+            vx_float32 scale;
+            /*!< \brief Number of data planes in image */
+            vx_uint32 planes;
+        } pmd;
 
-    /*!< \brief structure containing information about convolution
-                used when type is set to VX_TYPE_CONVOLUTION */
-    struct {
-        /*! The M dimension of the matrix */
-        vx_size rows;
-        /*! The N dimension of the matrix */
-        vx_size cols;
-    } conv;
+        /*!< \brief structure containing information about array
+                    used when type is set to VX_TYPE_ARRAY */
+        struct {
+            /*!< \brief The type of the Array items */
+            vx_enum item_type;
+            /*!< \brief The capacity of the Array */
+            vx_size capacity;
+        } arr;
 
-    /*!< \brief structure containing information about matrix
-                used when type is set to VX_TYPE_MATRIX */
-    struct {
-        /*! The value type of the matrix */
-        vx_enum type;
-        /*! The M dimension of the matrix */
-        vx_size rows;
-        /*! The N dimension of the matrix */
-        vx_size cols;
-    } mat;
+        /*!< \brief structure containing information about convolution
+                    used when type is set to VX_TYPE_CONVOLUTION */
+        struct {
+            /*! The M dimension of the matrix */
+            vx_size rows;
+            /*! The N dimension of the matrix */
+            vx_size cols;
+        } conv;
 
-    /*!< \brief structure containing information about distribution
-                used when type is set to VX_TYPE_DISTRIBUTION */
-    struct {
-        /*! Indicates the number of bins. */
-        vx_size bins;
-        /*! Indicates the start of the values to use (inclusive). */
-        vx_int32 offset;
-        /*! Indicates the total number of the consecutive values of the distribution interval. */
-        vx_uint32 range;
-    } dist;
+        /*!< \brief structure containing information about matrix
+                    used when type is set to VX_TYPE_MATRIX */
+        struct {
+            /*! The value type of the matrix */
+            vx_enum type;
+            /*! The M dimension of the matrix */
+            vx_size rows;
+            /*! The N dimension of the matrix */
+            vx_size cols;
+        } mat;
 
-    /*!< \brief structure containing information about tensor
-                used when type is set to VX_TYPE_TENSOR */
-    struct {
-        /*! \brief The number of dimensions in the tensor */
-        vx_size number_of_dimensions;
-        /*! \brief The size of all dimensions */
-        vx_size dimensions[TIVX_CONTEXT_MAX_TENSOR_DIMS];
-        /*! \brief The data type of tensor */
-        vx_enum data_type;
-        /*! \brief The fixed point precision of the tensor */
-        vx_int8 fixed_point_position;
-    } tensor;
+        /*!< \brief structure containing information about distribution
+                    used when type is set to VX_TYPE_DISTRIBUTION */
+        struct {
+            /*! Indicates the number of bins. */
+            vx_size bins;
+            /*! Indicates the start of the values to use (inclusive). */
+            vx_int32 offset;
+            /*! Indicates the total number of the consecutive values of the distribution interval. */
+            vx_uint32 range;
+        } dist;
 
-    /*!< \brief structure containing information about user data object
-                used when type is set to VX_TYPE_USER_DATA_OBJECT */
-    struct {
-        /*!< \brief The type name of the user data object. */
-        vx_char type_name[VX_MAX_REFERENCE_NAME];
-        /*!< \brief The size in bytes of the user data object */
-        vx_size size;
-    } user_data_object;
+        /*!< \brief structure containing information about tensor
+                    used when type is set to VX_TYPE_TENSOR */
+        struct {
+            /*! \brief The number of dimensions in the tensor */
+            vx_size number_of_dimensions;
+            /*! \brief The size of all dimensions */
+            vx_size dimensions[TIVX_CONTEXT_MAX_TENSOR_DIMS];
+            /*! \brief The data type of tensor */
+            vx_enum data_type;
+            /*! \brief The fixed point precision of the tensor */
+            vx_int8 fixed_point_position;
+        } tensor;
+
+        /*!< \brief structure containing information about user data object
+                    used when type is set to VX_TYPE_USER_DATA_OBJECT */
+        struct {
+            /*!< \brief The type name of the user data object. */
+            vx_char type_name[VX_MAX_REFERENCE_NAME];
+            /*!< \brief The size in bytes of the user data object */
+            vx_size size;
+        } user_data_object;
+
+    } object; /* Union to hold different types of metadata */
 
     /*!< \brief structure containing information about raw image
                 used when type is set to TIVX_TYPE_RAW_IMAGE */

--- a/utils/source/tivx_utils_ipc_ref_xfer.c
+++ b/utils/source/tivx_utils_ipc_ref_xfer.c
@@ -121,10 +121,10 @@ vx_status tivx_utils_export_ref_for_ipc_xfer(const vx_reference         ref,
 
             obj_desc = (tivx_obj_desc_image_t *)ref->obj_desc;
 
-            meta->img.width  = obj_desc->width;
-            meta->img.height = obj_desc->height;
-            meta->img.format = obj_desc->format;
-            meta->img.planes = obj_desc->planes;
+            meta->object.img.width  = obj_desc->width;
+            meta->object.img.height = obj_desc->height;
+            meta->object.img.format = obj_desc->format;
+            meta->object.img.planes = obj_desc->planes;
 
             /* Just translate plane[0] pointer. */
             numEntries = 1;
@@ -136,13 +136,13 @@ vx_status tivx_utils_export_ref_for_ipc_xfer(const vx_reference         ref,
 
             obj_desc = (tivx_obj_desc_tensor_t *)ref->obj_desc;
 
-            meta->tensor.number_of_dimensions = obj_desc->number_of_dimensions;
-            meta->tensor.data_type            = obj_desc->data_type;
-            meta->tensor.fixed_point_position = obj_desc->fixed_point_position;
+            meta->object.tensor.number_of_dimensions = obj_desc->number_of_dimensions;
+            meta->object.tensor.data_type            = obj_desc->data_type;
+            meta->object.tensor.fixed_point_position = obj_desc->fixed_point_position;
 
-            for (k = 0; k < meta->tensor.number_of_dimensions; k++)
+            for (k = 0; k < meta->object.tensor.number_of_dimensions; k++)
             {
-                meta->tensor.dimensions[k] = obj_desc->dimensions[k];
+                meta->object.tensor.dimensions[k] = obj_desc->dimensions[k];
             }
         }
         else if (meta->type == (vx_enum)VX_TYPE_USER_DATA_OBJECT)
@@ -151,9 +151,9 @@ vx_status tivx_utils_export_ref_for_ipc_xfer(const vx_reference         ref,
 
             obj_desc = (tivx_obj_desc_user_data_object_t *)ref->obj_desc;
 
-            meta->user_data_object.size = obj_desc->mem_size;
+            meta->object.user_data_object.size = obj_desc->mem_size;
 
-            memcpy(meta->user_data_object.type_name,
+            memcpy(meta->object.user_data_object.type_name,
                    (const void *)obj_desc->type_name,
                    sizeof(obj_desc->type_name));
         }
@@ -163,8 +163,8 @@ vx_status tivx_utils_export_ref_for_ipc_xfer(const vx_reference         ref,
 
             obj_desc = (tivx_obj_desc_array_t *)ref->obj_desc;
 
-            meta->arr.item_type = obj_desc->item_type;
-            meta->arr.capacity  = obj_desc->capacity;
+            meta->object.arr.item_type = obj_desc->item_type;
+            meta->object.arr.capacity  = obj_desc->capacity;
         }
         else if (meta->type == (vx_enum)VX_TYPE_CONVOLUTION)
         {
@@ -172,8 +172,8 @@ vx_status tivx_utils_export_ref_for_ipc_xfer(const vx_reference         ref,
 
             obj_desc = (tivx_obj_desc_convolution_t *)ref->obj_desc;
 
-            meta->conv.cols = obj_desc->columns;
-            meta->conv.rows = obj_desc->rows;
+            meta->object.conv.cols = obj_desc->columns;
+            meta->object.conv.rows = obj_desc->rows;
 
         }
         else if (meta->type == (vx_enum)VX_TYPE_MATRIX)
@@ -182,9 +182,9 @@ vx_status tivx_utils_export_ref_for_ipc_xfer(const vx_reference         ref,
 
             obj_desc = (tivx_obj_desc_matrix_t *)ref->obj_desc;
 
-            meta->mat.type = obj_desc->data_type;
-            meta->mat.cols = obj_desc->columns;
-            meta->mat.rows = obj_desc->rows;
+            meta->object.mat.type = obj_desc->data_type;
+            meta->object.mat.cols = obj_desc->columns;
+            meta->object.mat.rows = obj_desc->rows;
         }
         else if (meta->type == (vx_enum)VX_TYPE_DISTRIBUTION)
         {
@@ -192,9 +192,9 @@ vx_status tivx_utils_export_ref_for_ipc_xfer(const vx_reference         ref,
 
             obj_desc = (tivx_obj_desc_distribution_t *)ref->obj_desc;
 
-            meta->dist.bins   = obj_desc->num_bins;
-            meta->dist.offset = obj_desc->offset;
-            meta->dist.range  = obj_desc->range;
+            meta->object.dist.bins   = obj_desc->num_bins;
+            meta->object.dist.offset = obj_desc->offset;
+            meta->object.dist.range  = obj_desc->range;
 
         }
         else if (meta->type == (vx_enum)TIVX_TYPE_RAW_IMAGE)
@@ -219,14 +219,14 @@ vx_status tivx_utils_export_ref_for_ipc_xfer(const vx_reference         ref,
             img_ref      = (vx_reference)pyramid->img[0];
             img_obj_desc = (tivx_obj_desc_image_t *)img_ref->obj_desc;
 
-            meta->pmd.levels = obj_desc->num_levels;
-            meta->pmd.width  = obj_desc->width;
-            meta->pmd.height = obj_desc->height;
-            meta->pmd.scale  = obj_desc->scale;
-            meta->pmd.format = obj_desc->format;
-            meta->pmd.planes = img_obj_desc->planes;
+            meta->object.pmd.levels = obj_desc->num_levels;
+            meta->object.pmd.width  = obj_desc->width;
+            meta->object.pmd.height = obj_desc->height;
+            meta->object.pmd.scale  = obj_desc->scale;
+            meta->object.pmd.format = obj_desc->format;
+            meta->object.pmd.planes = img_obj_desc->planes;
 
-            numEntries = meta->pmd.levels;
+            numEntries = meta->object.pmd.levels;
         }
         else
         {
@@ -301,9 +301,9 @@ vx_status tivx_utils_import_ref_from_ipc_xfer(vx_context                context,
             vx_image    obj;
 
             obj = vxCreateImage(context,
-                                meta->img.width,
-                                meta->img.height,
-                                meta->img.format);
+                                meta->object.img.width,
+                                meta->object.img.height,
+                                meta->object.img.format);
 
             if (obj == NULL)
             {
@@ -318,10 +318,10 @@ vx_status tivx_utils_import_ref_from_ipc_xfer(vx_context                context,
             vx_tensor   obj;
 
             obj = vxCreateTensor(context,
-                                 meta->tensor.number_of_dimensions,
-                                 meta->tensor.dimensions,
-                                 meta->tensor.data_type,
-                                 meta->tensor.fixed_point_position);
+                                 meta->object.tensor.number_of_dimensions,
+                                 meta->object.tensor.dimensions,
+                                 meta->object.tensor.data_type,
+                                 meta->object.tensor.fixed_point_position);
 
             if (obj == NULL)
             {
@@ -336,8 +336,8 @@ vx_status tivx_utils_import_ref_from_ipc_xfer(vx_context                context,
             vx_user_data_object obj;
 
             obj = vxCreateUserDataObject(context,
-                                         meta->user_data_object.type_name,
-                                         meta->user_data_object.size,
+                                         meta->object.user_data_object.type_name,
+                                         meta->object.user_data_object.size,
                                          NULL);
 
             if (obj == NULL)
@@ -353,8 +353,8 @@ vx_status tivx_utils_import_ref_from_ipc_xfer(vx_context                context,
             vx_array    obj;
 
             obj = vxCreateArray(context,
-                                meta->arr.item_type,
-                                meta->arr.capacity);
+                                meta->object.arr.item_type,
+                                meta->object.arr.capacity);
 
             if (obj == NULL)
             {
@@ -369,8 +369,8 @@ vx_status tivx_utils_import_ref_from_ipc_xfer(vx_context                context,
             vx_convolution  obj;
 
             obj = vxCreateConvolution(context,
-                                      meta->conv.cols,
-                                      meta->conv.rows);
+                                      meta->object.conv.cols,
+                                      meta->object.conv.rows);
 
             if (obj == NULL)
             {
@@ -385,9 +385,9 @@ vx_status tivx_utils_import_ref_from_ipc_xfer(vx_context                context,
             vx_matrix   obj;
 
             obj = vxCreateMatrix(context,
-                                 meta->mat.type,
-                                 meta->mat.cols,
-                                 meta->mat.rows);
+                                 meta->object.mat.type,
+                                 meta->object.mat.cols,
+                                 meta->object.mat.rows);
 
             if (obj == NULL)
             {
@@ -402,9 +402,9 @@ vx_status tivx_utils_import_ref_from_ipc_xfer(vx_context                context,
             vx_distribution obj;
 
             obj = vxCreateDistribution(context,
-                                       meta->dist.bins,
-                                       meta->dist.offset,
-                                       meta->dist.range);
+                                       meta->object.dist.bins,
+                                       meta->object.dist.offset,
+                                       meta->object.dist.range);
 
             if (obj == NULL)
             {
@@ -436,11 +436,11 @@ vx_status tivx_utils_import_ref_from_ipc_xfer(vx_context                context,
             vx_pyramid  obj;
 
             obj = vxCreatePyramid(context,
-                                  meta->pmd.levels,
-                                  meta->pmd.scale,
-                                  meta->pmd.width,
-                                  meta->pmd.height,
-                                  meta->pmd.format);
+                                  meta->object.pmd.levels,
+                                  meta->object.pmd.scale,
+                                  meta->object.pmd.width,
+                                  meta->object.pmd.height,
+                                  meta->object.pmd.format);
 
             if (obj == NULL)
             {


### PR DESCRIPTION
Reduce the memory footprint of the OVX object meta exchange between processes, see structure:  tivx_utils_meta_format_t.
In this structure , there are metadata of the objects (such as img, arr, dist, tensor etc.) that are exchanged via the IPC between the applications.
Hence, instead of having them as structure where only one of them is used and others are left empty when sharing the object, we switched them to union to save memory.