### PR TITLE
Export/Import obj array util

### DIFF
--- a/utils/include/tivx_utils_ipc_ref_xfer.h
+++ b/utils/include/tivx_utils_ipc_ref_xfer.h
@@ -192,9 +192,9 @@ typedef struct
         /*!< \brief structure containing information about object array
                     used when type is set to VX_TYPE_OBJECT_ARRAY */
         struct {
-            /*!< \brief The number of image objects */
+            /*!< \brief The number of OVX objects */
             vx_uint32 num_items;
-            /*!< \brief VX type of the object, must be image */
+            /*!< \brief VX type of the object */
             vx_enum item_type;
         } object_array;
 
@@ -262,7 +262,7 @@ typedef struct
  *        could be transferred over Linux/QNX IPC mechanism to a remote process.
  *        This is just a wrapper for tivx_utils_export_ref_for_ipc_xfer.
  *
- * \param [in] ref  A valid openVX reference for an object array of images
+ * \param [in] ref  A valid openVX reference for an object array of OpenVX objects
  * \param [out] numMessages   Number of IPC messages after export
  * \param [out] ipcMsgHandle  Exported object array metadata
  * \param [out] ipcMsgArray   Array of pointers to exported item data
@@ -270,7 +270,7 @@ typedef struct
  * \return VX_SUCCESS on success, else failure
  *
  */
-vx_status vx_utils_export_ref_for_ipc_xfer_objarray(const vx_reference ref,
+vx_status tivx_utils_export_ref_for_ipc_xfer_objarray(const vx_reference ref,
                                                       vx_uint32 *numMessages,
                                                       tivx_utils_ref_ipc_msg_t *ipcMsgHandle,
                                                       tivx_utils_ref_ipc_msg_t ipcMsgArray[]);
@@ -307,16 +307,16 @@ vx_status tivx_utils_export_ref_for_ipc_xfer(const vx_reference         ref,
  *
  * \param [in] context  A valid openVX context
  * \param [in] ipcMsgHandle  Exported object array information
- * \param [in] ipcMsgArray   Array of exported image information
+ * \param [in] ipcMsgArray   Array of exported objects information
  * \param [in,out] ref  A valid openVX reference to import. If *ref is NULL,
- *                 then a new object will be allocated with the imported
+ *                 then a new object array will be allocated with the imported
  *                 handles and returned. If *ref is not NULL then the object
  *                 will be used to import the handles.
  *
  * \return VX_SUCCESS on success, else failure
  *
  */
-vx_status vx_utils_import_ref_from_ipc_xfer_objarray(vx_context                context,
+vx_status tivx_utils_import_ref_from_ipc_xfer_objarray(vx_context                context,
                                                        tivx_utils_ref_ipc_msg_t *ipcMsgHandle,
                                                        tivx_utils_ref_ipc_msg_t  ipcMsgArray[],
                                                        vx_reference             *ref);

--- a/utils/include/tivx_utils_ipc_ref_xfer.h
+++ b/utils/include/tivx_utils_ipc_ref_xfer.h
@@ -190,8 +190,7 @@ typedef struct
         } user_data_object;
 
         /*!< \brief structure containing information about object array
-                    used when type is set to VX_TYPE_OBJECT_ARRAY
-                    NOTE: assume the underlying type is vx_image */
+                    used when type is set to VX_TYPE_OBJECT_ARRAY */
         struct {
             /*!< \brief The number of image objects */
             vx_uint32 num_items;

--- a/utils/include/tivx_utils_ipc_ref_xfer.h
+++ b/utils/include/tivx_utils_ipc_ref_xfer.h
@@ -199,11 +199,11 @@ typedef struct
             vx_enum item_type;
         } object_array;
 
+        /*!< \brief structure containing information about raw image
+                    used when type is set to TIVX_TYPE_RAW_IMAGE */
+        tivx_raw_image_create_params_t raw_image;
+        
     } object; /* Union to hold different types of metadata */
-
-    /*!< \brief structure containing information about raw image
-                used when type is set to TIVX_TYPE_RAW_IMAGE */
-    tivx_raw_image_create_params_t raw_image;
 
 } tivx_utils_meta_format_t;
 

--- a/utils/include/tivx_utils_ipc_ref_xfer.h
+++ b/utils/include/tivx_utils_ipc_ref_xfer.h
@@ -189,6 +189,16 @@ typedef struct
             vx_size size;
         } user_data_object;
 
+        /*!< \brief structure containing information about object array
+                    used when type is set to VX_TYPE_OBJECT_ARRAY
+                    NOTE: assume the underlying type is vx_image */
+        struct {
+            /*!< \brief The number of image objects */
+            vx_uint32 num_items;
+            /*!< \brief VX type of the object, must be image */
+            vx_enum item_type;
+        } object_array;
+
     } object; /* Union to hold different types of metadata */
 
     /*!< \brief structure containing information about raw image
@@ -249,6 +259,24 @@ typedef struct
 } tivx_utils_ref_ipc_msg_t;
 
 /**
+ * \brief Export the object array, so that the information
+ *        could be transferred over Linux/QNX IPC mechanism to a remote process.
+ *        This is just a wrapper for tivx_utils_export_ref_for_ipc_xfer.
+ *
+ * \param [in] ref  A valid openVX reference for an object array of images
+ * \param [out] numMessages   Number of IPC messages after export
+ * \param [out] ipcMsgHandle  Exported object array metadata
+ * \param [out] ipcMsgArray   Array of pointers to exported item data
+ *
+ * \return VX_SUCCESS on success, else failure
+ *
+ */
+vx_status vx_utils_export_ref_for_ipc_xfer_objarray(const vx_reference ref,
+                                                      vx_uint32 *numMessages,
+                                                      tivx_utils_ref_ipc_msg_t *ipcMsgHandle,
+                                                      tivx_utils_ref_ipc_msg_t ipcMsgArray[]);
+
+/**
  * \brief Export the internal handle information of a valid reference as a
  *        buffer descriptor along with meta information so that the information
  *        could be transferred over Linux/QNX IPC mechanism to a remote process.
@@ -272,6 +300,27 @@ typedef struct
  */
 vx_status tivx_utils_export_ref_for_ipc_xfer(const vx_reference         ref,
                                              tivx_utils_ref_ipc_msg_t  *ipcMsg);
+
+/**
+ * \brief Import the external handle information of a valid reference as a
+ *        buffer descriptor along with meta information exchanged via Linux/
+ *        QNX IPC mechanism. 
+ *
+ * \param [in] context  A valid openVX context
+ * \param [in] ipcMsgHandle  Exported object array information
+ * \param [in] ipcMsgArray   Array of exported image information
+ * \param [in,out] ref  A valid openVX reference to import. If *ref is NULL,
+ *                 then a new object will be allocated with the imported
+ *                 handles and returned. If *ref is not NULL then the object
+ *                 will be used to import the handles.
+ *
+ * \return VX_SUCCESS on success, else failure
+ *
+ */
+vx_status vx_utils_import_ref_from_ipc_xfer_objarray(vx_context                context,
+                                                       tivx_utils_ref_ipc_msg_t *ipcMsgHandle,
+                                                       tivx_utils_ref_ipc_msg_t  ipcMsgArray[],
+                                                       vx_reference             *ref);
 
 /**
  * \brief Import the external handle information of a valid reference as a

--- a/utils/source/tivx_utils_ipc_ref_xfer.c
+++ b/utils/source/tivx_utils_ipc_ref_xfer.c
@@ -428,15 +428,16 @@ vx_status vx_utils_import_ref_from_ipc_xfer_objarray(vx_context                c
                                                 (const uint32_t *)refDesc->handleSizes,
                                                 ipcMsgArray[i].numFd);
 
+                    VX_PRINT(VX_ZONE_INFO, "Importing item reference %d\n", i);
                     if (vxStatus != (vx_status)VX_SUCCESS)
                     {
                         VX_PRINT(VX_ZONE_ERROR,
                                 "tivxReferenceImportHandle() failed.\n");
+                        break;
                     }
-                }                
-                VX_PRINT(VX_ZONE_INFO, "Importing item reference %d\n", i);
+                }
             }
-            if (vxStatus != (vx_status)VX_SUCCESS)
+            if (vxStatus == (vx_status)VX_SUCCESS)
             {            
                  *ref = vxCastRefFromObjectArray(objArrayRefs);
             }
@@ -444,7 +445,7 @@ vx_status vx_utils_import_ref_from_ipc_xfer_objarray(vx_context                c
     }
     else
     {
-        VX_PRINT(VX_ZONE_ERROR, "the imported pbject is not a vx_objarray \n");
+        VX_PRINT(VX_ZONE_ERROR, "the imported pbject is not a vx_object_array \n");
         vxStatus = (vx_status)VX_FAILURE;        
     }
 

--- a/utils/source/tivx_utils_ipc_ref_xfer.c
+++ b/utils/source/tivx_utils_ipc_ref_xfer.c
@@ -589,11 +589,10 @@ vx_status tivx_utils_import_ref_from_ipc_xfer_objarray(vx_context             co
     /* Check if we have been provided a valid reference to work with. */
     if (vxStatus == (vx_status)VX_SUCCESS)
     {
+         meta = &refDesc->meta;
         if (meta->type == (vx_enum)VX_TYPE_OBJECT_ARRAY)
         {
-            meta = &refDesc->meta;
             numItems = meta->object.object_array.num_items;
-            
             if (*ref == NULL)
             {
                 /* create the obj array based on the type of object contained into it */
@@ -609,8 +608,8 @@ vx_status tivx_utils_import_ref_from_ipc_xfer_objarray(vx_context             co
                 *ref = vxCastRefFromObjectArray(objArrayRefs);
             }
             /* check if the input array items are from the same type of the imported ones */
-            vx_reference item = vxGetObjectArrayItem(*ref, 0);
-            if (item->type != ipcMsgArray[0].refDesc.meta.type)
+            vx_reference itemRef = vxGetObjectArrayItem(vxCastRefAsObjectArray(*ref, NULL), 0);
+            if (itemRef->type != ipcMsgArray[0].refDesc.meta.type)
             {
                 VX_PRINT(VX_ZONE_ERROR, "The input object array items are not of the same type as the exported ones\n");
                 vxStatus = (vx_status)VX_FAILURE;
@@ -639,7 +638,7 @@ vx_status tivx_utils_import_ref_from_ipc_xfer_objarray(vx_context             co
                     if (vxStatus == (vx_status)VX_SUCCESS)
                     {
                         /* Import the reference handles. */
-                        vx_reference item = vxGetObjectArrayItem(*ref, i);
+                        vx_reference item = vxGetObjectArrayItem(vxCastRefAsObjectArray(*ref, NULL), i);
                         vxStatus =
                             tivxReferenceImportHandle(item,
                                                     (const void **)ptrs,
@@ -656,7 +655,7 @@ vx_status tivx_utils_import_ref_from_ipc_xfer_objarray(vx_context             co
                     }
                 }
             }
-            vxReleaseReference(&item);
+            vxReleaseReference(&itemRef);
         }
         else
         {

--- a/utils/source/tivx_utils_ipc_ref_xfer.c
+++ b/utils/source/tivx_utils_ipc_ref_xfer.c
@@ -296,9 +296,9 @@ vx_status tivx_utils_export_ref_for_ipc_xfer(const vx_reference         ref,
 
             obj_desc = (tivx_obj_desc_raw_image_t *)ref->obj_desc;
 
-            tivx_obj_desc_memcpy(&meta->raw_image,
-                   &obj_desc->params,
-                   sizeof(tivx_raw_image_create_params_t));
+            tivx_obj_desc_memcpy(&meta->object.raw_image,
+                                 &obj_desc->params,
+                                 sizeof(tivx_raw_image_create_params_t));
         }
         else if (meta->type == (vx_enum)VX_TYPE_PYRAMID)
         {
@@ -616,7 +616,7 @@ vx_status tivx_utils_import_ref_from_ipc_xfer(vx_context                context,
             tivx_raw_image_create_params_t *p;
             tivx_raw_image                  obj;
 
-            p = (tivx_raw_image_create_params_t *)&meta->raw_image;
+            p = (tivx_raw_image_create_params_t *)&meta->object.raw_image;
 
             obj = tivxCreateRawImage(context, p);
 

--- a/utils/source/tivx_utils_ipc_ref_xfer.c
+++ b/utils/source/tivx_utils_ipc_ref_xfer.c
@@ -360,9 +360,10 @@ vx_status vx_utils_import_ref_from_ipc_xfer_objarray(vx_context                c
     void                           *phyAddr[VX_IPC_MAX_VX_PLANES];    
     tivx_utils_ref_desc_t          *refDesc;
     uint32_t                        numItems;
-    uint32_t                        i;
+    uint32_t                        i,j;
     vx_status                       vxStatus = VX_SUCCESS;
 
+    /* refdesc for the object array itself */
     refDesc = (tivx_utils_ref_desc_t *)&ipcMsgHandle->refDesc;
 
     /* Validate the arguments. */
@@ -389,45 +390,47 @@ vx_status vx_utils_import_ref_from_ipc_xfer_objarray(vx_context                c
 
         if (meta->type == (vx_enum)VX_TYPE_OBJECT_ARRAY)
         {
-            /* Import all the items from the array, gather the references */
+            /* create the obj array based on the type of object contained into it */
             numItems = meta->object.object_array.num_items;
             vx_object_array objArrayRefs;
-            vx_reference exemplarRef = NULL;
-            vxStatus = tivx_utils_import_ref_from_ipc_xfer(context, &ipcMsgArray[0], &exemplarRef);
+            vx_reference itemRef = NULL;
+            vxStatus = tivx_utils_import_ref_from_ipc_xfer(context, &ipcMsgArray[0], &itemRef);
             if (vxStatus != VX_SUCCESS)
             {
                 VX_PRINT(VX_ZONE_ERROR, "Could not import the item reference\n");
-            }                       
-            objArrayRefs = vxCreateObjectArray(context, exemplarRef, numItems);
-            vxReleaseReference(&exemplarRef);
+            }
+            objArrayRefs = vxCreateObjectArray(context, itemRef, numItems);
+            vxReleaseReference(&itemRef);
 
             /* Import the remaining items */
             for(i = 0; i < numItems; i++)
             {
-                for (i = 0; i < ipcMsgArray[i].numFd; i++)
+                refDesc = (tivx_utils_ref_desc_t *)&ipcMsgArray[i].refDesc;
+                for (j = 0; j < ipcMsgArray[i].numFd; j++)
                 {
                     /* Translate FD corresponding to plane[i]. */
-                    vxStatus = tivxMemTranslateFd((uint64_t)ipcMsgArray[i].fd[i],
-                                                refDesc->handleSizes[i],
-                                                &ptrs[i],
-                                                &phyAddr[i]);
+                    vxStatus = tivxMemTranslateFd((uint64_t)ipcMsgArray[i].fd[j],
+                                                refDesc->handleSizes[j],
+                                                &ptrs[j],
+                                                &phyAddr[j]);
 
                     if (vxStatus != (vx_status)VX_SUCCESS)
                     {
                         VX_PRINT(VX_ZONE_ERROR, "tivxMemTranslateFd() failed for "
-                                "FD [%d]\n", i);
+                                "FD [%d]\n", j);
                         break;
                     }
                 }
                 if (vxStatus == (vx_status)VX_SUCCESS)
                 {
                     /* Import the reference handles. */
+                    itemRef = vxGetObjectArrayItem(objArrayRefs, i);
                     vxStatus =
-                        tivxReferenceImportHandle(vxGetObjectArrayItem(objArrayRefs, i),
+                        tivxReferenceImportHandle(itemRef,
                                                 (const void **)ptrs,
                                                 (const uint32_t *)refDesc->handleSizes,
                                                 ipcMsgArray[i].numFd);
-
+                    vxReleaseReference(&itemRef);
                     VX_PRINT(VX_ZONE_INFO, "Importing item reference %d\n", i);
                     if (vxStatus != (vx_status)VX_SUCCESS)
                     {
@@ -494,7 +497,6 @@ vx_status tivx_utils_import_ref_from_ipc_xfer(vx_context                context,
         if (meta->type == (vx_enum)VX_TYPE_IMAGE)
         {
             vx_image    obj;
-
             obj = vxCreateImage(context,
                                 meta->object.img.width,
                                 meta->object.img.height,


### PR DESCRIPTION
Hi,
this PR extends the export / import utility for the IPC to support the object array type.
The export function exposes the meta for the object array itself and each element compositing it.
The import function received two ipc structs, one representing the object array and the other for the different elements of the obj array.
please have a look if you want to take it over,